### PR TITLE
Fix blog cover image using internal Docker host

### DIFF
--- a/frontend/server/api/drupal/blog/[slug].get.ts
+++ b/frontend/server/api/drupal/blog/[slug].get.ts
@@ -3,6 +3,10 @@
 
 import type { DrupalBlogPost } from '~/types/drupal'
 
+// Internal SSR host (config.drupalBaseUrl, e.g. http://drupal:80) is used to fetch
+// JSON:API. Asset URLs returned to the browser must use the PUBLIC host instead.
+const DRUPAL_PUBLIC_URL = process.env.DRUPAL_PUBLIC_URL || 'https://drupal.madsnorgaard.net'
+
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
   const base = config.drupalBaseUrl
@@ -49,13 +53,13 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'Post not found' })
   }
 
-  return transformNode(data.data, data.included ?? [], base)
+  return transformNode(data.data, data.included ?? [])
 })
 
-function transformNode(node: any, included: any[], base: string): DrupalBlogPost {
+function transformNode(node: any, included: any[]): DrupalBlogPost {
   const rawImg = resolveImage(node.relationships?.field_image, included)
   const coverImage = rawImg
-    ? { ...rawImg, url: rawImg.url.startsWith('http') ? rawImg.url : `${base}${rawImg.url}` }
+    ? { ...rawImg, url: rawImg.url.startsWith('http') ? rawImg.url : `${DRUPAL_PUBLIC_URL}${rawImg.url}` }
     : undefined
   return {
     id: node.id,


### PR DESCRIPTION
## Problem
Cover images on single article pages (e.g. `/writing/self-hosted-monitoring-single-vps`) fail to load with `net::ERR_NAME_NOT_RESOLVED`. The `<img>` src was `https://drupal/sites/default/files/...` — the internal Docker hostname leaking to the browser.

## Cause
`server/api/drupal/blog/[slug].get.ts` prepended `config.drupalBaseUrl` (`http://drupal:80`, the internal SSR fetch host) to the relative file path from JSON:API, instead of the public Drupal host.

## Fix
Use a `DRUPAL_PUBLIC_URL` constant for asset URLs, matching the existing pattern in `projects.get.ts`. Dropped the now-unused `base` param from `transformNode`.

Verified the broken URL via the live page; the list route was unaffected (it returns `coverImage: undefined`).