### PR TITLE
Fix missing gallery images in post bodies

### DIFF
--- a/frontend/pages/post/[slug].vue
+++ b/frontend/pages/post/[slug].vue
@@ -178,6 +178,50 @@ useHead({
   text-underline-offset: 0.2em;
 }
 
+/* Body images - full-width within the column, consistent with other post types. */
+.post-page__content :deep(img) {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 2rem auto;
+  border-radius: 6px;
+}
+
+.post-page__content :deep(figure) {
+  margin: 0;
+}
+
+.post-page__content :deep(figcaption) {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-muted);
+  margin-top: 0.6rem;
+  text-align: center;
+}
+
+/* Legacy WordPress gallery blocks (Gutenberg + Mauer Stills plugin):
+   stack items in a single column. The plugin's flex-grid and absolute-
+   positioned-image CSS is absent in the headless frontend, so its
+   aspect-ratio padding box would otherwise leave empty gaps. */
+.post-page__content :deep(.wp-block-gallery),
+.post-page__content :deep(.blocks-gallery-grid) {
+  display: block;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.post-page__content :deep(.blocks-gallery-item) {
+  margin: 0;
+}
+
+.post-page__content :deep(.mauer-stills-img-box-wrapper),
+.post-page__content :deep(.mauer-stills-img-box) {
+  padding: 0 !important;
+  width: auto !important;
+  height: auto !important;
+}
+
 .post-page__terms {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/server/api/wp/posts/[slug].get.ts
+++ b/frontend/server/api/wp/posts/[slug].get.ts
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event) => {
     title: decodeEntities(post.title?.rendered ?? ''),
     slug: post.slug ?? '',
     date: post.date ?? '',
-    content: post.content?.rendered ?? '',
+    content: await hydrateGalleryImages(post.content?.rendered ?? '', base),
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
     featuredImage: media ? {
       src: media.source_url ?? null,

--- a/frontend/server/utils/wp-fetch.ts
+++ b/frontend/server/utils/wp-fetch.ts
@@ -94,6 +94,66 @@ export function stripTags(html: string): string {
 }
 
 /**
+ * Hydrate legacy "Mauer Stills" gallery images in WP rendered content.
+ *
+ * That gallery plugin emits <img> tags carrying only a `data-id` (the WP
+ * attachment ID) and no `src` - it filled the src in client-side at runtime.
+ * In the headless frontend that plugin JS never runs, so the images render
+ * empty. This resolves each data-id to its real source_url via the WP media
+ * REST API and injects the src/alt attributes server-side.
+ *
+ * Returns the html unchanged when there are no such images or the media
+ * lookup fails (degrades gracefully rather than throwing).
+ */
+export async function hydrateGalleryImages(html: string, base: string): Promise<string> {
+  if (!html) return html
+
+  const imgRe = /<img\b[^>]*>/gi
+
+  // Collect attachment IDs from <img> tags that have a data-id but no src.
+  const ids = new Set<number>()
+  for (const tag of html.match(imgRe) ?? []) {
+    if (/\bsrc\s*=/i.test(tag)) continue
+    const m = tag.match(/\bdata-id\s*=\s*["']?(\d+)/i)
+    if (m) ids.add(Number(m[1]))
+  }
+  if (ids.size === 0) return html
+
+  // Batch-resolve the IDs to source URLs in a single REST call.
+  const media = await wpFetch<any[]>(
+    `${base}/wp-json/wp/v2/media?include=${[...ids].join(',')}&per_page=100&_fields=id,source_url,alt_text`
+  )
+  if (!media?.length) return html
+
+  const byId = new Map<number, { src: string; alt: string }>()
+  for (const m of media) {
+    if (m?.id && m?.source_url) {
+      byId.set(Number(m.id), { src: m.source_url, alt: m.alt_text || '' })
+    }
+  }
+  if (byId.size === 0) return html
+
+  // Inject src (+ alt + lazy loading) into each matching img tag.
+  return html.replace(imgRe, (tag) => {
+    if (/\bsrc\s*=/i.test(tag)) return tag
+    const m = tag.match(/\bdata-id\s*=\s*["']?(\d+)/i)
+    const info = m && byId.get(Number(m[1]))
+    if (!info) return tag
+    const altAttr = /\balt\s*=/i.test(tag) ? '' : ` alt="${escapeAttr(info.alt)}"`
+    const loadingAttr = /\bloading\s*=/i.test(tag) ? '' : ' loading="lazy"'
+    return tag.replace(/^<img\b/i, `<img src="${escapeAttr(info.src)}"${altAttr}${loadingAttr}`)
+  })
+}
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
  * Validate a URL slug: lowercase alphanumeric and hyphens only.
  */
 export function isValidSlug(slug: string): boolean {


### PR DESCRIPTION
## Problem
Legacy WordPress gallery blocks (Gutenberg + Mauer Stills plugin) emit `<img>` tags carrying only a `data-id` and no `src` - the plugin filled the src client-side at runtime, which never happens in the headless frontend, so the images rendered empty (e.g. the xenophobic-attacks post).

## Fix
- Add `hydrateGalleryImages()` server util that resolves each `data-id` to its real `source_url` via the WP media REST API and injects `src`/`alt`. Batched into one call, degrades gracefully, idempotent.
- Apply it in the `posts/[slug]` handler - covers all 4 affected posts (#790, #962, #862, #712).
- Style body images and gallery blocks full-width in a single column, consistent with the `writing` post type, and neutralise the plugin's aspect-ratio padding box that left empty gaps.

Verified in a real browser: images load and stack full-width.