### PR TITLE
Wall polish: chronological order, click-nav, SoundCloud fix

### DIFF
--- a/frontend/components/event/MixPlayer.vue
+++ b/frontend/components/event/MixPlayer.vue
@@ -29,14 +29,20 @@
 <script setup lang="ts">
 // A nostalgia button: streams the Cold Turkey SoundCloud while you wander the
 // wall. Uses the public SoundCloud widget iframe (no account, no API key).
-const profileUrl = 'https://soundcloud.com/coldturkeysa'
+const profileUrl = 'https://soundcloud.com/coldturkeysa' // friendly link shown to humans
+
+// The widget resolves the canonical (pre-resolved) user URL rather than the
+// vanity slug - the slug occasionally fails with "we couldn't find that
+// profile" because the widget's vanity lookup flakes. This numeric form is the
+// exact one SoundCloud's own oEmbed/Share-embed uses, so it never mis-resolves.
+const widgetUrl = 'https://api.soundcloud.com/users/12417503'
 
 // Two-way so the page can start the mix (e.g. when the memory reel begins).
 const open = defineModel<boolean>('open', { default: false })
 
 const embedSrc = computed(() => {
   const params = new URLSearchParams({
-    url: profileUrl,
+    url: widgetUrl,
     color: '#d0243e',
     auto_play: 'true',
     hide_related: 'true',

--- a/frontend/components/photo/PhotoLightbox.vue
+++ b/frontend/components/photo/PhotoLightbox.vue
@@ -32,9 +32,11 @@
             :src="current?.src ?? ''"
             :alt="current?.alt ?? ''"
             class="lightbox__image"
-            :class="{ 'lightbox__image--kenburns': reel }"
+            :class="{ 'lightbox__image--kenburns': reel, 'lightbox__image--nav': images.length > 1 }"
             :style="morphName ? { viewTransitionName: morphName } : undefined"
-            @click.stop="next"
+            @click.stop="onImageClick"
+            @touchstart.passive="onTouchStart"
+            @touchend.passive="onTouchEnd"
           />
           <div class="lightbox__hud">
             <button
@@ -127,6 +129,25 @@ function next() {
 function prev() {
   if (props.images.length <= 1) return
   emit('update:index', (props.index - 1 + props.images.length) % props.images.length)
+}
+
+// Click the left half of the photo to go back, the right half to go forward.
+function onImageClick(e: MouseEvent) {
+  if (props.images.length <= 1) return
+  const el = e.currentTarget as HTMLElement
+  const rect = el.getBoundingClientRect()
+  if (e.clientX - rect.left < rect.width / 2) prev()
+  else next()
+}
+
+// Swipe left/right on touch devices.
+let touchStartX = 0
+function onTouchStart(e: TouchEvent) {
+  touchStartX = e.changedTouches[0]?.clientX ?? 0
+}
+function onTouchEnd(e: TouchEvent) {
+  const dx = (e.changedTouches[0]?.clientX ?? 0) - touchStartX
+  if (Math.abs(dx) > 40) (dx < 0 ? next() : prev())
 }
 
 function close() {
@@ -357,13 +378,13 @@ onUnmounted(() => {
   top: 50%;
   transform: translateY(-50%);
   z-index: 3;
-  background: none;
-  border: 1px solid var(--color-border);
-  color: var(--color-muted);
+  background: rgba(8, 8, 8, 0.55);
+  border: 1px solid var(--color-muted);
+  color: var(--color-text);
   font-family: var(--font-mono);
-  font-size: 1.25rem;
-  width: 2.5rem;
-  height: 2.5rem;
+  font-size: 1.4rem;
+  width: 2.75rem;
+  height: 2.75rem;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/server/api/event/photos/index.get.ts
+++ b/frontend/server/api/event/photos/index.get.ts
@@ -49,8 +49,10 @@ export default defineEventHandler(async (event) => {
     const termId = await resolveTermId(base, wantSlug)
     params.set('per_page', String(PER_PAGE))
     params.set('page', String(page))
+    // Ascending so each night plays forward as it happened (the importer
+    // inserts posts in filename order = Lightroom's capture sequence).
     params.set('orderby', 'date')
-    params.set('order', 'desc')
+    params.set('order', 'asc')
     if (termId) params.set('event_set', String(termId))
   }
 


### PR DESCRIPTION
Three improvements to the Cold Turkey wall (all built earlier but landed on the branch after #29 squash-merged, so not yet live):

- **Chronological order** — each night now plays oldest-shot-first so it reads as a timeline of how the night unfolded (was newest-first).
- **Click-to-navigate** — click the left/right half of a photo to go back/next, plus swipe on touch, and more visible arrows.
- **SoundCloud fix** — the mix player resolves the canonical user URL (was intermittently failing 'we couldn't find that profile' on the vanity slug).

Verified: production build clean previously; one-line/low-risk changes.