### PR TITLE
Fix Cold Turkey set filter (wrong WP REST taxonomy param)

### DIFF
--- a/frontend/server/api/event/photos/index.get.ts
+++ b/frontend/server/api/event/photos/index.get.ts
@@ -5,11 +5,10 @@
 //   page  - Page number (default 1)
 //   set   - event_set child-term slug (a "night"). Omit for all nights blended.
 //
-// With no `set`, photos are queried under the event's PARENT term, which (for a
-// hierarchical taxonomy) WP includes all descendant nights for - i.e. the whole
-// event. With a `set`, only that night's photos are returned.
+// With no `set`, no taxonomy filter is applied, so every event_photo (all
+// nights) is returned. With a `set`, only that night's photos are returned,
+// filtered via the taxonomy REST base `event-sets` (not the taxonomy name).
 
-const EVENT_SLUG = 'cold-turkey-cape-town'
 const PER_PAGE = 50
 
 export default defineEventHandler(async (event) => {
@@ -40,20 +39,22 @@ export default defineEventHandler(async (event) => {
     params.set('per_page', String(ids.length))
     params.set('orderby', 'include')
   } else {
-    // Resolve which event_set term to filter by, then map to its term ID.
-    // WP REST taxonomy filters expect term IDs, not slugs.
-    const wantSlug =
-      query.set && typeof query.set === 'string' && isValidSlug(query.set)
-        ? query.set
-        : EVENT_SLUG
-    const termId = await resolveTermId(base, wantSlug)
     params.set('per_page', String(PER_PAGE))
     params.set('page', String(page))
     // Ascending so each night plays forward as it happened (the importer
     // inserts posts in filename order = Lightroom's capture sequence).
     params.set('orderby', 'date')
     params.set('order', 'asc')
-    if (termId) params.set('event_set', String(termId))
+    // Filter to a single night when a valid set slug is given. The WP REST
+    // taxonomy filter param is the taxonomy's REST BASE ('event-sets'), NOT the
+    // taxonomy name ('event_set') — the latter is silently ignored, which is why
+    // picking a set used to still show every night. No set => no taxonomy filter
+    // => all nights (every event_photo). (Single-event site; if more events are
+    // added, filter the no-set case by the parent term's child IDs.)
+    if (query.set && typeof query.set === 'string' && isValidSlug(query.set)) {
+      const termId = await resolveTermId(base, query.set)
+      if (termId) params.set('event-sets', String(termId))
+    }
   }
 
   const url = `${base}/wp-json/wp/v2/event-photos?${params.toString()}`

--- a/frontend/tests/e2e/cold-turkey-share.spec.ts
+++ b/frontend/tests/e2e/cold-turkey-share.spec.ts
@@ -62,4 +62,17 @@ test.describe('Cold Turkey per-photo sharing', () => {
       await expect(rail.locator('.toppicks__item').first()).toBeVisible()
     }
   })
+
+  // Regression: ?set must actually narrow the wall. The WP REST tax filter param
+  // is the rest_base ('event-sets'), not the taxonomy name ('event_set') — using
+  // the wrong one silently returned every night.
+  test('selecting a set filters the wall to that night', async ({ request }) => {
+    const all = await (await request.get('/api/event/photos?page=1')).json()
+    const sets = (await (await request.get('/api/event/sets')).json())?.sets ?? []
+    test.skip(sets.length < 2, 'need >=2 sets to prove filtering')
+    const slug = sets[0].slug
+    const filtered = await (await request.get(`/api/event/photos?page=1&set=${slug}`)).json()
+    expect(filtered.total).toBeGreaterThan(0)
+    expect(filtered.total).toBeLessThan(all.total)
+  })
 })


### PR DESCRIPTION
Selecting a set still showed **all nights**. Root cause: the BFF filtered `event-photos` with `?event_set=<id>` (taxonomy *name*), but WP REST keys taxonomy filters by the taxonomy's **rest_base** (`event-sets`) — so the param was silently ignored and every request returned all 188 photos.

Verified directly: `event_set=95` → total 188 (ignored); `event-sets=95` → total 87 (correct).

- Use `event-sets=<termId>` for a selected night.
- No-set 'all nights' now applies **no** taxonomy filter (returns every `event_photo`) — the old parent-term filter was likewise ignored, so this preserves behaviour correctly. (Single-event site; if more events are added, filter no-set by the parent's child IDs.)
- Adds a regression e2e test asserting `?set` narrows the total.