### PR TITLE
Hide empty event sets from the night chips

### DIFF
--- a/frontend/server/api/event/sets.get.ts
+++ b/frontend/server/api/event/sets.get.ts
@@ -21,13 +21,17 @@ export default defineEventHandler(async (event) => {
     `${base}/wp-json/wp/v2/event-sets?parent=${parentId}&per_page=100&orderby=name&order=asc&_fields=id,name,slug,count,parent`
   )
 
-  const sets = (Array.isArray(children) ? children : []).map((t: any) => ({
-    id: t.id,
-    name: decodeEntities(t.name ?? ''),
-    slug: t.slug ?? '',
-    count: t.count ?? 0,
-    parent: t.parent ?? parentId,
-  }))
+  const sets = (Array.isArray(children) ? children : [])
+    .map((t: any) => ({
+      id: t.id,
+      name: decodeEntities(t.name ?? ''),
+      slug: t.slug ?? '',
+      count: Number(t.count ?? 0),
+      parent: t.parent ?? parentId,
+    }))
+    // Only nights that actually have photos — an empty set is a leftover term
+    // (e.g. from a folder-name mismatch on import) and must not show as a chip.
+    .filter((s) => s.count > 0)
 
   return { event: EVENT_SLUG, parentId, sets }
 })


### PR DESCRIPTION
An `event_set` term with **0 photos** (a leftover term from a folder-name mismatch on import) was still returned by `/api/event/sets` and rendered as a stubborn empty night chip on the Cold Turkey wall. Filter to `count > 0` so only nights that actually have photos show — robust against any future phantom terms.