### PR TITLE
Order night chips chronologically (oldest first)

### DIFF
--- a/frontend/server/api/event/sets.get.ts
+++ b/frontend/server/api/event/sets.get.ts
@@ -4,6 +4,17 @@
 
 const EVENT_SLUG = 'cold-turkey-cape-town'
 
+// Sort key from a "D Month YYYY - …" night name so the chips read as a timeline
+// (oldest first). Names that don't parse sort to the end.
+const MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+function nightTime(name: string): number {
+  const m = name.match(/^(\d{1,2})\s+([A-Za-z]{3,})\s+(\d{4})/)
+  if (!m) return Number.MAX_SAFE_INTEGER
+  const mon = MONTHS.indexOf(m[2].slice(0, 3).toLowerCase())
+  if (mon < 0) return Number.MAX_SAFE_INTEGER
+  return Date.UTC(Number(m[3]), mon, Number(m[1]))
+}
+
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
   const base = config.photoSiteUrl
@@ -32,6 +43,9 @@ export default defineEventHandler(async (event) => {
     // Only nights that actually have photos — an empty set is a leftover term
     // (e.g. from a folder-name mismatch on import) and must not show as a chip.
     .filter((s) => s.count > 0)
+    // Timeline order: oldest night first (the first Cold Turkey photographed),
+    // parsed from the "D Month YYYY - …" name rather than WP's alphabetical sort.
+    .sort((a, b) => nightTime(a.name) - nightTime(b.name))
 
   return { event: EVENT_SLUG, parentId, sets }
 })


### PR DESCRIPTION
The night-filter chips were sorted by name. With the `D Month YYYY - …` naming convention that comes out alphabetical (16 Sep → 27 May → 28 Oct → 9 Dec), not as a timeline.

This parses the date out of each night's name and sorts ascending, so the chips read as a timeline starting with the first Cold Turkey photographed (27 May 2012) — matching the wall, which already runs oldest-first.

Names that don't parse fall to the end. No WP/Drupal changes.