### PR TITLE
Show a loading spinner while switching nights

### DIFF
--- a/frontend/components/event/PhotoWall.vue
+++ b/frontend/components/event/PhotoWall.vue
@@ -1,13 +1,23 @@
 <template>
   <div class="wall">
-    <EventWallSection
-      v-for="chunk in chunks"
-      :key="chunk.start"
-      :photos="chunk.items"
-      :start-index="chunk.start"
-      :morph-id="morphId"
-      @open="$emit('open', $event)"
-    />
+    <!-- Switching nights: a spinner anchored near the top of the wall so the
+         user gets immediate feedback while the new set's first page loads. Kept
+         outside the dimmed grid so it stays fully visible. -->
+    <div v-if="busy" class="wall__busy" role="status" aria-live="polite">
+      <span class="wall__spinner" aria-hidden="true" />
+      <span class="wall__busy-label">loading photographs…</span>
+    </div>
+
+    <div class="wall__grid" :class="{ 'wall__grid--busy': busy }">
+      <EventWallSection
+        v-for="chunk in chunks"
+        :key="chunk.start"
+        :photos="chunk.items"
+        :start-index="chunk.start"
+        :morph-id="morphId"
+        @open="$emit('open', $event)"
+      />
+    </div>
 
     <!-- Infinite-scroll sentinel -->
     <div ref="sentinel" class="wall__sentinel" />
@@ -31,6 +41,7 @@ const props = defineProps<{
   photos: EventPhoto[]
   hasMore: boolean
   loading: boolean
+  busy?: boolean
   morphId?: number | null
 }>()
 
@@ -66,6 +77,52 @@ useIntersectionObserver(
 .wall {
   max-width: 100%;
   padding: 0 2px 4rem;
+  position: relative;
+}
+
+/* Dim the outgoing set while the new one loads (badge sits outside this). */
+.wall__grid--busy {
+  opacity: 0.35;
+  transition: opacity 150ms ease;
+  pointer-events: none;
+}
+
+.wall__busy {
+  position: sticky;
+  top: 1rem;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  margin: 1.5rem auto;
+  width: fit-content;
+  padding: 0.55rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.wall__spinner {
+  width: 0.95rem;
+  height: 0.95rem;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: wall-spin 700ms linear infinite;
+}
+
+@keyframes wall-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wall__spinner { animation-duration: 1800ms; }
 }
 
 .wall__sentinel {

--- a/frontend/pages/photographs/cold-turkey-cape-town.vue
+++ b/frontend/pages/photographs/cold-turkey-cape-town.vue
@@ -65,6 +65,7 @@
         :photos="activeList"
         :has-more="showFavourites ? false : hasMore"
         :loading="loading"
+        :busy="switching && !showFavourites"
         :morph-id="morphId"
         @open="openIndex"
         @load-more="loadMore"
@@ -144,13 +145,17 @@ const activeSet = computed(() =>
 
 // ─── Data: first page (SSR) + the night chips ───────────────────
 
-const { data: initial } = await useAsyncData(
+const { data: initial, status: setStatus } = await useAsyncData(
   () => `ctct-photos-${activeSet.value ?? 'all'}`,
   () => $fetch('/api/event/photos', {
     query: { ...(activeSet.value ? { set: activeSet.value } : {}), page: 1 },
   }),
   { watch: [activeSet] }
 )
+
+// True while a different night's first page is being fetched (chip switch), so
+// the wall can show a spinner instead of silently holding the old set.
+const switching = computed(() => setStatus.value === 'pending')
 
 const { data: setsData } = await useAsyncData('ctct-sets', () => $fetch('/api/event/sets'))
 const sets = computed<EventSet[]>(() => (setsData.value as any)?.sets ?? [])


### PR DESCRIPTION
Tapping a night chip refetches that set's first page (`useAsyncData` watches `activeSet`), but the wall kept showing the previous night's photos until the fetch resolved — on a 100+ photo set the page looked frozen.

This surfaces the fetch `status` as a **busy** state: the outgoing grid dims to 35% and a sticky spinner badge ("loading photographs…") shows near the top of the wall until the new set's first page arrives. Reduced-motion safe; favourites view excluded.