### PR TITLE
Fix darkroom spotlight on scroll; lift tiles toward the viewer

### DIFF
--- a/frontend/components/event/PhotoWall.vue
+++ b/frontend/components/event/PhotoWall.vue
@@ -15,6 +15,7 @@
         :photos="chunk.items"
         :start-index="chunk.start"
         :morph-id="morphId"
+        :darkroom="darkroom"
         @open="$emit('open', $event)"
       />
     </div>
@@ -42,6 +43,7 @@ const props = defineProps<{
   hasMore: boolean
   loading: boolean
   busy?: boolean
+  darkroom?: boolean
   morphId?: number | null
 }>()
 

--- a/frontend/components/event/WallAtmosphere.vue
+++ b/frontend/components/event/WallAtmosphere.vue
@@ -15,7 +15,11 @@
 <script setup lang="ts">
 const props = defineProps<{ spotlight: boolean }>()
 
-const { x, y } = useMouse({ touch: false })
+// `type: 'client'` => viewport coordinates. The spot overlay is position:fixed,
+// so it must track the cursor relative to the viewport; the default 'page'
+// coords include scrollY, which pushed the light pool off the bottom of the
+// screen as soon as you scrolled down the wall.
+const { x, y } = useMouse({ touch: false, type: 'client' })
 
 // Only enable the spotlight for fine pointers (mouse/trackpad).
 const finePointer = ref(false)
@@ -51,15 +55,26 @@ const spotStyle = computed(() => ({
     radial-gradient(ellipse at center, transparent 55%, rgba(8, 8, 8, 0.45) 100%);
 }
 
-/* The moving spotlight mask. */
+/* The moving spotlight: a warm pool of light at the cursor, the rest of the
+   wall sinking into near-black. Two layers - a soft amber bloom in the clear
+   centre, and the darkening surround. */
 .atmos__spot {
-  background: radial-gradient(
-    circle 240px at var(--mx, 50%) var(--my, 50%),
-    transparent 0,
-    transparent 34%,
-    rgba(8, 8, 8, 0.78) 78%
-  );
-  transition: background 60ms linear;
+  background:
+    radial-gradient(
+      circle 260px at var(--mx, 50%) var(--my, 50%),
+      rgba(255, 210, 160, 0.06) 0,
+      rgba(255, 210, 160, 0.02) 22%,
+      transparent 40%
+    ),
+    radial-gradient(
+      circle 260px at var(--mx, 50%) var(--my, 50%),
+      transparent 0,
+      transparent 30%,
+      rgba(6, 6, 6, 0.7) 62%,
+      rgba(4, 4, 4, 0.88) 82%
+    );
+  transition: background 70ms linear;
+  will-change: background;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/components/event/WallSection.vue
+++ b/frontend/components/event/WallSection.vue
@@ -2,6 +2,7 @@
   <section
     ref="el"
     class="wall-section"
+    :class="{ 'wall-section--dark': darkroom }"
     :style="!visible && collapsedHeight ? { height: collapsedHeight + 'px' } : null"
   >
     <template v-if="visible">
@@ -44,6 +45,7 @@ const props = defineProps<{
   photos: EventPhoto[]
   startIndex: number
   morphId?: number | null
+  darkroom?: boolean
 }>()
 
 defineEmits<{ (e: 'open', index: number): void }>()
@@ -103,18 +105,54 @@ useIntersectionObserver(
   position: relative;
   break-inside: avoid;
   overflow: hidden;
+  /* Lift toward the viewer on hover: the tile itself scales up and rises above
+     its neighbours (z-index), so the photo reads as coming forward rather than
+     just cropping in. */
+  transition: transform 360ms cubic-bezier(0.2, 0, 0, 1), box-shadow 360ms ease;
+  transform-origin: center;
+}
+
+.tile:hover,
+.tile:focus-visible {
+  transform: scale(1.09) translateY(-4px);
+  z-index: 3;
+  box-shadow:
+    0 22px 48px -14px rgba(0, 0, 0, 0.75),
+    0 0 0 1px rgba(255, 255, 255, 0.05);
+  overflow: visible;
 }
 
 .tile__img {
   display: block;
   width: 100%;
   height: auto;
+  border-radius: inherit;
   transition: transform 500ms ease, filter 300ms ease;
 }
 
-.tile:hover .tile__img {
-  transform: scale(1.04);
+/* A touch of extra inner zoom on top of the tile lift, for depth. */
+.tile:hover .tile__img,
+.tile:focus-visible .tile__img {
+  transform: scale(1.05);
   filter: brightness(1.12);
+}
+
+/* Darkroom: every photo sinks to a low ember; the moving spotlight overlay
+   reveals what it passes over, and the hovered tile blooms back to full life. */
+.wall-section--dark .tile__img {
+  filter: brightness(0.55) saturate(0.82) contrast(1.02);
+}
+.wall-section--dark .tile:hover .tile__img,
+.wall-section--dark .tile:focus-visible .tile__img {
+  filter: brightness(1.2) saturate(1.08) contrast(1.02);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tile { transition: box-shadow 360ms ease; }
+  .tile:hover,
+  .tile:focus-visible { transform: none; }
+  .tile:hover .tile__img,
+  .tile:focus-visible .tile__img { transform: none; }
 }
 
 .tile__overlay {

--- a/frontend/pages/photographs/cold-turkey-cape-town.vue
+++ b/frontend/pages/photographs/cold-turkey-cape-town.vue
@@ -66,6 +66,7 @@
         :has-more="showFavourites ? false : hasMore"
         :loading="loading"
         :busy="switching && !showFavourites"
+        :darkroom="darkroom"
         :morph-id="morphId"
         @open="openIndex"
         @load-more="loadMore"

--- a/frontend/tests/e2e/cold-turkey-darkroom.spec.ts
+++ b/frontend/tests/e2e/cold-turkey-darkroom.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page, type Locator } from '@playwright/test'
+
+const PAGE = '/photographs/cold-turkey-cape-town'
+
+// Run serially against one page: the Nuxt dev server (the Playwright target) is
+// prone to a vue-router SSR crash under many rapid renders, so we load the page
+// once and drive the rest through client-side interaction.
+test.describe.configure({ mode: 'serial' })
+
+async function gotoWall(page: Page): Promise<void> {
+  await page.goto(PAGE)
+  // Tiles render once the first page of photos resolves.
+  await page.locator('.tile').first().waitFor({ state: 'visible', timeout: 20000 })
+}
+
+function readVar(spot: Locator, name: string): Promise<number> {
+  return spot.evaluate((el, n) => {
+    const v = (el as HTMLElement).style.getPropertyValue(n) || getComputedStyle(el).getPropertyValue(n)
+    return parseFloat(v)
+  }, name)
+}
+
+async function enterDarkroom(page: Page): Promise<void> {
+  const btn = page.getByRole('button', { name: /darkroom/i })
+  await btn.waitFor({ state: 'visible', timeout: 20000 })
+  await btn.click()
+}
+
+test.describe('Cold Turkey darkroom + depth', () => {
+  test('darkroom toggle reveals the spotlight and dims the wall', async ({ page }) => {
+    await gotoWall(page)
+    // Off by default: no spotlight overlay, wall not dimmed.
+    await expect(page.locator('.atmos__spot')).toHaveCount(0)
+    await expect(page.locator('.wall-section--dark').first()).toHaveCount(0)
+
+    await enterDarkroom(page)
+    await page.mouse.move(500, 360)
+
+    await expect(page.locator('.atmos__spot')).toBeVisible()
+    await expect(page.locator('.wall-section--dark').first()).toBeVisible()
+
+    // The button reports its on-state.
+    await expect(page.getByRole('button', { name: /darkroom/i })).toHaveClass(/ctct-tool--on/)
+  })
+
+  test('spotlight follows the cursor in VIEWPORT coords, even after scrolling', async ({ page }) => {
+    await gotoWall(page)
+    await enterDarkroom(page)
+    const spot = page.locator('.atmos__spot')
+
+    // At the top, the light pool sits where the cursor is.
+    await page.mouse.move(500, 360)
+    await page.waitForTimeout(120)
+    expect(await readVar(spot, '--mx')).toBeCloseTo(500, 0)
+    expect(await readVar(spot, '--my')).toBeCloseTo(360, 0)
+
+    // Scroll deep into the wall, then move the cursor to a fresh viewport point.
+    // The pool must stay at that viewport Y (~320), NOT page Y (~320 + 1600).
+    // This is the regression for the "spotlight stops further down the page" bug
+    // (it used page coordinates against a position:fixed overlay).
+    await page.mouse.wheel(0, 1600)
+    await page.waitForTimeout(120)
+    await page.mouse.move(540, 320)
+    await page.waitForTimeout(120)
+
+    const my = await readVar(spot, '--my')
+    expect(my).toBeLessThan(800) // viewport-relative, not page-relative (~1920)
+    expect(my).toBeCloseTo(320, 0)
+    expect(await readVar(spot, '--mx')).toBeCloseTo(540, 0)
+  })
+
+  test('hovering a tile lifts it toward the viewer (scale > 1)', async ({ page }) => {
+    await gotoWall(page)
+    const tile = page.locator('.tile').first()
+    await tile.scrollIntoViewIfNeeded()
+
+    const before = await tile.evaluate((el) => getComputedStyle(el).transform)
+    await tile.hover()
+    await page.waitForTimeout(420) // transform transition
+
+    const after = await tile.evaluate((el) => getComputedStyle(el).transform)
+    expect(after).not.toBe(before)
+    // matrix(a, b, c, d, tx, ty) — a is scaleX; hover scales to 1.09.
+    const scaleX = await tile.evaluate((el) => {
+      const m = new DOMMatrixReadOnly(getComputedStyle(el).transform)
+      return m.a
+    })
+    expect(scaleX).toBeGreaterThan(1.02)
+  })
+})


### PR DESCRIPTION
## Darkroom
- **Bug fix:** the spotlight overlay is `position: fixed` (viewport-relative) but tracked the cursor with `useMouse()` **page** coordinates, which include `scrollY`. Scroll down the wall and the light pool slid off the bottom of the screen — "the darkroom cursor effect stops further down the page." Switched to `type: 'client'` so it follows the cursor at any scroll depth.
- Richer two-layer pool (warm amber bloom in the clear centre + deeper near-black surround).
- Darkroom now sinks every photo to a low ember (brightness/saturation down); the moving spotlight reveals what it passes over, and the hovered tile blooms back to full life. `darkroom` prop threaded page → wall → section.

## Depth ("images getting larger towards the viewer")
- Hovering a tile now lifts the **whole tile** toward the viewer — scale 1.09 + slight rise + drop shadow + `z-index` above its neighbours — instead of just cropping in inside a clipped box (the old `scale(1.04)` on the image was clipped by `overflow: hidden`). Keyboard `:focus-visible` gets the same lift; reduced-motion drops the transform.

## Tests
`tests/e2e/cold-turkey-darkroom.spec.ts` (3 passing):
- darkroom toggle reveals the spotlight + dims the wall
- **regression:** after scrolling 1600px the spotlight stays at the viewport Y, not page Y
- hovering a tile lifts it (computed scale > 1)