### PR TITLE
Fix horizontal overflow on small phones

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -274,7 +274,9 @@ a {
 
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  /* min(300px, 100%) lets a column shrink below 300px on very narrow phones
+     (<=320px) instead of forcing a fixed 300px track that overflows. */
+  grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
   gap: 1.5rem;
 }
 
@@ -425,7 +427,11 @@ a {
   }
 
   .site-nav {
-    gap: 1rem;
+    /* Wrap + tighter column gap so the 5 links never force a horizontal
+       scroll on small phones (was overflowing ~3px at 375px and clipping
+       the last link). Wrapping keeps it safe down to 320px too. */
+    flex-wrap: wrap;
+    gap: 0.5rem 0.85rem;
   }
 
   /* ── Post list card ── */

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -93,6 +93,13 @@ useHead({ title: 'Projects | Mads Nørgaard' })
   color: var(--color-accent);
 }
 
+/* The name+description column must be allowed to shrink (min-width:0) so a long
+   description wraps instead of forcing the flex row past the viewport on narrow
+   phones. */
+.repo-row > div:first-child {
+  min-width: 0;
+}
+
 .repo-row__name {
   font-family: var(--font-mono);
   font-weight: 500;


### PR DESCRIPTION
A Playwright device sweep of the live site (320–1440px, all 7 main pages) found a hairline horizontal scroll on narrow phones from three sources:

| Page | Cause | Fix |
|---|---|---|
| All (top nav) | 5-link row didn't wrap — overflowed ~3px at **375px** (current iPhone SE) and clipped the last link | nav wraps + tighter column gap |
| Home grid | `minmax(300px, 1fr)` forced a fixed 300px track, overflowing <320px | `minmax(min(300px, 100%), 1fr)` |
| /projects repo rows | flex name+desc column lacked `min-width:0`, long descriptions pushed the row past the viewport | add `min-width:0` |

**Verified:** zero horizontal overflow on every page at 320 / 360 / 375 / 768 / 1440. Tablet (portrait + landscape) and desktop were already clean.