### PR TITLE
Harden remaining card grids against sub-320px overflow

### DIFF
--- a/frontend/pages/archive/index.vue
+++ b/frontend/pages/archive/index.vue
@@ -136,7 +136,9 @@ useHead({
 
 .collection-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  /* min(300px, 100%) so columns shrink below 300px on very narrow phones
+     instead of forcing a fixed track that overflows. */
+  grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
   gap: 1rem;
 }
 

--- a/frontend/pages/proj/index.vue
+++ b/frontend/pages/proj/index.vue
@@ -135,7 +135,7 @@ useHead({
 
 .project-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
   gap: 1.5rem;
 }
 

--- a/frontend/pages/series/[slug].vue
+++ b/frontend/pages/series/[slug].vue
@@ -137,7 +137,7 @@ useHead({
 
 .photo-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(200px, 100%), 1fr));
   gap: 0.5rem;
 }
 

--- a/frontend/pages/subject/[slug].vue
+++ b/frontend/pages/subject/[slug].vue
@@ -137,7 +137,7 @@ useHead({
 
 .photo-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(200px, 100%), 1fr));
   gap: 0.5rem;
 }
 


### PR DESCRIPTION
Follow-up to the responsive sweep. The archive, /proj, series and subject grids still used `minmax(<n>px, 1fr)`, which forces a fixed track that overflows on very narrow phones (archive overflowed +4px at 320px). Wrapped every grid min track in `min(<n>px, 100%)` so columns shrink instead of overflowing. Verified clean at 320px locally; all current device widths were already clean.