### PR TITLE
Make the mix player reliable (fix autoplay race + lying UI)

### DIFF
--- a/frontend/components/event/MixPlayer.vue
+++ b/frontend/components/event/MixPlayer.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="mix" :class="{ 'mix--open': open }">
-    <!-- The SoundCloud player bar. Mounted only while playing so closing it
-         actually stops the audio (no Widget API needed). Auto-plays on open
-         because the toggle is a user gesture. -->
-    <div v-if="open" class="mix__bar">
+    <!-- The SoundCloud player bar. The iframe is created on first play and then
+         kept alive (we pause/resume via the Widget API rather than remounting),
+         so there's no autoplay race from injecting a fresh iframe after the
+         click. Shown while open so a manual tap is always possible. -->
+    <div v-show="loaded && open" class="mix__bar">
       <iframe
+        v-if="loaded"
+        ref="frame"
         class="mix__frame"
         title="Cold Turkey Cape Town mix"
         scrolling="no"
@@ -12,39 +15,56 @@
         allow="autoplay; encrypted-media"
         :src="embedSrc"
       />
+      <p v-if="blocked" class="mix__hint">
+        Your browser blocked autoplay, tap ► in the player to start.
+      </p>
       <a class="mix__source" :href="profileUrl" target="_blank" rel="noopener noreferrer">
         soundcloud.com/coldturkeysa ↗
       </a>
     </div>
 
-    <button class="mix__toggle" type="button" @click="open = !open">
-      <span class="mix__eq" :class="{ 'mix__eq--on': open }" aria-hidden="true">
+    <button class="mix__toggle" type="button" @click="toggle">
+      <span class="mix__eq" :class="{ 'mix__eq--on': playing }" aria-hidden="true">
         <i></i><i></i><i></i>
       </span>
-      <span class="mix__label">{{ open ? 'Stop the mix' : 'Play the mix' }}</span>
+      <span class="mix__label">{{ label }}</span>
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
 // A nostalgia button: streams the Cold Turkey SoundCloud while you wander the
-// wall. Uses the public SoundCloud widget iframe (no account, no API key).
+// wall. Uses the public SoundCloud Widget API (no account, no key) so we can
+// drive play/pause from the user's actual gesture and reflect the *real*
+// playing state, rather than trusting an auto_play iframe param that browsers
+// (Safari/iOS especially) silently block.
 const profileUrl = 'https://soundcloud.com/coldturkeysa' // friendly link shown to humans
 
-// The widget resolves the canonical (pre-resolved) user URL rather than the
-// vanity slug - the slug occasionally fails with "we couldn't find that
-// profile" because the widget's vanity lookup flakes. This numeric form is the
-// exact one SoundCloud's own oEmbed/Share-embed uses, so it never mis-resolves.
-const widgetUrl = 'https://api.soundcloud.com/users/12417503'
+// The widget resolves the canonical (pre-resolved) numeric user URL rather than
+// the vanity slug; the slug occasionally fails with "we couldn't find that
+// profile" because the widget's vanity lookup flakes. This is the exact form
+// SoundCloud's own Share-embed uses, so it never mis-resolves.
+const widgetUser = 'https://api.soundcloud.com/users/12417503'
 
 // Two-way so the page can start the mix (e.g. when the memory reel begins).
 const open = defineModel<boolean>('open', { default: false })
 
+const loaded = ref(false)   // iframe has been created (lazy, on first play)
+const ready = ref(false)    // Widget API is bound and the player is ready
+const playing = ref(false)  // REAL playback state, from the widget's events
+const blocked = ref(false)  // autoplay was denied; the user must tap play
+
+const frame = ref<HTMLIFrameElement | null>(null)
+let widget: any = null
+let blockTimer: ReturnType<typeof setTimeout> | null = null
+
+// auto_play stays false: we call .play() ourselves inside the gesture so the
+// browser ties playback to the real user activation.
 const embedSrc = computed(() => {
   const params = new URLSearchParams({
-    url: widgetUrl,
+    url: widgetUser,
     color: '#d0243e',
-    auto_play: 'true',
+    auto_play: 'false',
     hide_related: 'true',
     show_comments: 'false',
     show_user: 'true',
@@ -54,6 +74,91 @@ const embedSrc = computed(() => {
   })
   return `https://w.soundcloud.com/player/?${params.toString()}`
 })
+
+const label = computed(() => {
+  if (playing.value) return 'Stop the mix'
+  if (blocked.value) return 'Tap play below'
+  if (open.value) return 'Starting…'
+  return 'Play the mix'
+})
+
+// Load the SoundCloud Widget API script once.
+let apiPromise: Promise<any> | null = null
+function loadApi(): Promise<any> {
+  if (!import.meta.client) return Promise.reject(new Error('client only'))
+  if ((window as any).SC?.Widget) return Promise.resolve((window as any).SC)
+  if (apiPromise) return apiPromise
+  apiPromise = new Promise((resolve, reject) => {
+    const s = document.createElement('script')
+    s.src = 'https://w.soundcloud.com/player/api.js'
+    s.async = true
+    s.onload = () => resolve((window as any).SC)
+    s.onerror = () => reject(new Error('SoundCloud API failed to load'))
+    document.head.appendChild(s)
+  })
+  return apiPromise
+}
+
+function clearBlockTimer() {
+  if (blockTimer) { clearTimeout(blockTimer); blockTimer = null }
+}
+
+// Create the iframe + bind the Widget API the first time we need to play.
+async function ensureWidget(): Promise<void> {
+  if (widget) return
+  loaded.value = true
+  await nextTick() // let the iframe render so SC.Widget can attach to it
+  const SC = await loadApi()
+  if (!frame.value) return
+  widget = SC.Widget(frame.value)
+  widget.bind(SC.Widget.Events.READY, () => {
+    ready.value = true
+    if (open.value) requestPlay() // resume any intent expressed before ready
+  })
+  widget.bind(SC.Widget.Events.PLAY, () => {
+    playing.value = true
+    blocked.value = false
+    clearBlockTimer()
+  })
+  widget.bind(SC.Widget.Events.PAUSE, () => { playing.value = false })
+  widget.bind(SC.Widget.Events.FINISH, () => { playing.value = false })
+  widget.bind(SC.Widget.Events.ERROR, () => { blocked.value = true })
+}
+
+// Ask the widget to play, and arm a short timer: if no PLAY event arrives, the
+// browser blocked autoplay, so reveal the player and prompt a manual tap.
+function requestPlay() {
+  if (!widget || !ready.value) return
+  widget.play()
+  clearBlockTimer()
+  blockTimer = setTimeout(() => {
+    if (!playing.value) blocked.value = true
+  }, 1800)
+}
+
+async function play() {
+  blocked.value = false
+  await ensureWidget()
+  if (ready.value) requestPlay()
+  // else: the READY handler will call requestPlay() once bound.
+}
+
+function pause() {
+  clearBlockTimer()
+  widget?.pause()
+  playing.value = false
+}
+
+function toggle() {
+  open.value = !open.value
+}
+
+// `open` is the source of truth for intent; the page can flip it (e.g. the reel
+// starting) and we react the same as a direct toggle.
+watch(open, (v) => { v ? play() : pause() })
+
+onMounted(() => { if (open.value) play() })
+onBeforeUnmount(clearBlockTimer)
 </script>
 
 <style scoped>
@@ -80,6 +185,15 @@ const embedSrc = computed(() => {
   width: 100%;
   height: 120px;
   border: 0;
+}
+
+.mix__hint {
+  margin: 0.4rem 0 0.1rem;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  line-height: 1.4;
+  letter-spacing: 0.03em;
+  color: var(--color-accent);
 }
 
 .mix__source {
@@ -113,7 +227,7 @@ const embedSrc = computed(() => {
 .mix__toggle:hover { background: var(--color-accent-dim); }
 .mix--open .mix__toggle { border-color: var(--color-accent); color: var(--color-accent); }
 
-/* Little equaliser glyph: three bars, animated only while playing. */
+/* Little equaliser glyph: three bars, animated only while actually playing. */
 .mix__eq {
   display: inline-flex;
   align-items: flex-end;

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -167,7 +167,9 @@ export default defineNuxtConfig({
         // CSP: allow Nuxt SSR inline scripts, Google Fonts, self for everything else
         'Content-Security-Policy': [
           "default-src 'self'",
-          "script-src 'self' 'unsafe-inline' https://analytics.theazanianprepper.online",
+          // w.soundcloud.com: the SoundCloud Widget API (player/api.js) that
+          // drives the Cold Turkey mix player's play/pause.
+          "script-src 'self' 'unsafe-inline' https://analytics.theazanianprepper.online https://w.soundcloud.com",
           "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
           "font-src 'self' https://fonts.gstatic.com",
           "img-src 'self' data: https:",

--- a/frontend/tests/e2e/cold-turkey-mix.spec.ts
+++ b/frontend/tests/e2e/cold-turkey-mix.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const PAGE = '/photographs/cold-turkey-cape-town'
+
+// Headless Chromium allows autoplay, so the SoundCloud Widget API actually
+// plays here — which lets us assert on the REAL playing state (the EQ + label
+// are driven by the widget's PLAY/PAUSE events, not merely by the open flag).
+test.describe('Cold Turkey mix player', () => {
+  test('clicking play actually starts audio and reflects real state', async ({ page }) => {
+    await page.goto(PAGE)
+    const toggle = page.locator('button.mix__toggle')
+    await expect(toggle).toBeVisible({ timeout: 15000 })
+
+    // Idle: not playing.
+    await expect(page.locator('.mix__label')).toHaveText(/play the mix/i)
+    await expect(page.locator('.mix__eq--on')).toHaveCount(0)
+
+    // The Widget API script must be allowed by CSP and load.
+    await toggle.click()
+    await page.waitForFunction(() => !!(window as any).SC?.Widget, null, { timeout: 15000 })
+
+    // The PLAY event flips the EQ on + label to "Stop the mix". This only
+    // happens on a real PLAY event, so it proves audio started, not just intent.
+    await expect(page.locator('.mix__eq--on')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('.mix__label')).toHaveText(/stop the mix/i)
+
+    // The autoplay-blocked hint must NOT be showing when playback succeeded.
+    await expect(page.locator('.mix__hint')).toHaveCount(0)
+  })
+
+  test('pause stops playback but keeps the iframe (no remount race)', async ({ page }) => {
+    await page.goto(PAGE)
+    const toggle = page.locator('button.mix__toggle')
+    await toggle.click()
+    await expect(page.locator('.mix__eq--on')).toBeVisible({ timeout: 15000 })
+
+    // Pause.
+    await toggle.click()
+    await expect(page.locator('.mix__eq--on')).toHaveCount(0, { timeout: 5000 })
+    await expect(page.locator('.mix__label')).toHaveText(/play the mix/i)
+    // Iframe persists so resume is instant and gesture-tied (no fresh-iframe
+    // autoplay race).
+    await expect(page.locator('.mix__frame')).toHaveCount(1)
+
+    // Resume on the existing widget.
+    await toggle.click()
+    await expect(page.locator('.mix__eq--on')).toBeVisible({ timeout: 15000 })
+  })
+})


### PR DESCRIPTION
## Problem
The Cold Turkey mix player injected a **fresh SoundCloud iframe with `auto_play=true` only after the click**. Browsers that gate autoplay (Safari/iOS, sometimes Chrome) silently blocked it. Worse, the EQ animation and "Stop the mix" label were driven by the `open` flag — so the UI claimed to be playing even when no audio started, with no recovery path. (Playwright disables the autoplay gate, which is why it looked fine in automation but failed for real users.)

## Fix — rebuild on the SoundCloud Widget API
- **Lazy-create the iframe once and keep it alive**; pause/resume via the API instead of remounting → removes the inject-after-click race.
- Drive `play()` from the **real user gesture** (`auto_play=false` in the URL).
- Reflect the **actual** PLAY/PAUSE/FINISH events in the EQ + label, so the UI never lies about playback state.
- If no PLAY event arrives ~1.8s after `play()`, mark autoplay **blocked** and show the player with a "tap ► to start" hint instead of pretending.
- Allow `https://w.soundcloud.com` in the CSP `script-src` (the Widget API `player/api.js`).

## Verified (Playwright, live widget)
- Click play → Widget API loads past CSP → audio actually streams (sndcdn mp3 segments) → EQ on + "Stop the mix".
- Pause → audio stops, EQ off, **iframe persists** (no remount).
- Resume → plays again on the live widget.
- New spec `tests/e2e/cold-turkey-mix.spec.ts` (2 passing) asserts on the real PLAY-event state, not just intent.