### PR TITLE
Photo wall: justified-rows masonry with feature-band rhythm

### DIFF
--- a/frontend/components/event/PhotoWall.vue
+++ b/frontend/components/event/PhotoWall.vue
@@ -8,12 +8,12 @@
       <span class="wall__busy-label">loading photographs…</span>
     </div>
 
-    <div class="wall__grid" :class="{ 'wall__grid--busy': busy }">
+    <div ref="gridEl" class="wall__grid" :class="{ 'wall__grid--busy': busy }">
       <EventWallSection
-        v-for="chunk in chunks"
-        :key="chunk.start"
-        :photos="chunk.items"
-        :start-index="chunk.start"
+        v-for="section in sections"
+        :key="section.key"
+        :rows="section.rows"
+        :est-height="section.estHeight"
         :morph-id="morphId"
         :darkroom="darkroom"
         @open="$emit('open', $event)"
@@ -34,9 +34,10 @@
 </template>
 
 <script setup lang="ts">
-import type { EventPhoto } from '~/types/event'
+import type { EventPhoto, WallRow } from '~/types/event'
 
-const CHUNK = 50
+const GAP = 4 // px gap between tiles and rows (matches WallSection CSS)
+const ROWS_PER_SECTION = 8 // windowing granularity (≈ one page of photos)
 
 const props = defineProps<{
   photos: EventPhoto[]
@@ -52,12 +53,91 @@ const emit = defineEmits<{
   (e: 'load-more'): void
 }>()
 
-// Group the flat accumulated list into fixed-size sections so each can
-// independently virtualize (see WallSection).
-const chunks = computed(() => {
-  const out: { start: number; items: EventPhoto[] }[] = []
-  for (let i = 0; i < props.photos.length; i += CHUNK) {
-    out.push({ start: i, items: props.photos.slice(i, i + CHUNK) })
+// Measure the live wall width so the justified layout fills it exactly.
+const gridEl = ref<HTMLElement | null>(null)
+const containerW = ref(1200) // SSR / first-paint default; re-measured on mount
+
+useResizeObserver(gridEl, (entries) => {
+  const w = entries[0]?.contentRect.width ?? 0
+  if (w) containerW.value = w
+})
+onMounted(() => {
+  const w = gridEl.value?.clientWidth ?? 0
+  if (w) containerW.value = w
+})
+
+// Base row height by breakpoint. The justified algorithm scales each row around
+// its target so rows always reach full width.
+function baseHeight(w: number): number {
+  return w <= 540 ? 165 : w <= 1024 ? 205 : 255
+}
+
+// Designed rhythm: most rows sit at the base height; periodic rows aim taller,
+// which packs fewer (so bigger) photos into them - "feature" bands that give the
+// wall a dynamic cadence even when every photo is the same shape. Deterministic
+// per row index, so it's stable across re-layout and SSR/client. Length 13 (out
+// of step with the section size) keeps the peaks from lining up into stripes.
+const RHYTHM = [1, 1, 1, 1.45, 1, 1, 1.25, 1, 1.6, 1, 1, 1.3, 1]
+// Feature bands are softened on narrow screens so a row never drops to 1-2 huge
+// tiles on a phone.
+function rowTarget(base: number, rowIndex: number, narrow: boolean): number {
+  const f = RHYTHM[rowIndex % RHYTHM.length]
+  return base * (narrow ? 1 + (f - 1) * 0.5 : f)
+}
+
+function aspect(p: EventPhoto): number {
+  const im = p.images
+  return im && im.width && im.height ? im.width / im.height : 1.5
+}
+
+// Justified-rows layout: walk photos in order, packing each row until it would
+// exceed the container width at that row's target height, then scale the row to
+// fit exactly. Preserves strict order, fills full width, leaves no gaps. The
+// final (incomplete) row keeps its natural target height, left-aligned.
+const layout = computed<WallRow[]>(() => {
+  const W = containerW.value
+  const base = baseHeight(W)
+  const narrow = W <= 540
+  const rows: WallRow[] = []
+  let cur: { photo: EventPhoto; ar: number; index: number }[] = []
+  let arSum = 0
+  let rowIndex = 0
+  let target = rowTarget(base, rowIndex, narrow)
+
+  const flush = (stretch: boolean) => {
+    if (!cur.length) return
+    // Justify to the exact width (stretch); the trailing row keeps its target.
+    const h = stretch ? (W - (cur.length - 1) * GAP) / arSum : target
+    rows.push({
+      height: Math.round(h),
+      items: cur.map((c) => ({ photo: c.photo, index: c.index, width: Math.round(c.ar * h) })),
+    })
+    cur = []
+    arSum = 0
+    rowIndex += 1
+    target = rowTarget(base, rowIndex, narrow)
+  }
+
+  props.photos.forEach((photo, index) => {
+    const ar = aspect(photo)
+    cur.push({ photo, ar, index })
+    arSum += ar
+    // A taller target fills the width with fewer (bigger) photos -> feature band.
+    if (arSum * target + (cur.length - 1) * GAP >= W) flush(true)
+  })
+  flush(false)
+  return rows
+})
+
+// Chunk rows into windowable sections, each with a deterministic height estimate
+// so off-screen blocks reserve the right space before they are ever measured.
+const sections = computed(() => {
+  const rows = layout.value
+  const out: { key: number; rows: WallRow[]; estHeight: number }[] = []
+  for (let i = 0; i < rows.length; i += ROWS_PER_SECTION) {
+    const slice = rows.slice(i, i + ROWS_PER_SECTION)
+    const estHeight = slice.reduce((s, r) => s + r.height + GAP, 0)
+    out.push({ key: slice[0]?.items[0]?.index ?? i, rows: slice, estHeight })
   }
   return out
 })

--- a/frontend/components/event/WallSection.vue
+++ b/frontend/components/event/WallSection.vue
@@ -3,47 +3,59 @@
     ref="el"
     class="wall-section"
     :class="{ 'wall-section--dark': darkroom }"
-    :style="!visible && collapsedHeight ? { height: collapsedHeight + 'px' } : null"
+    :style="spacerStyle"
   >
     <template v-if="visible">
-      <button
-        v-for="(photo, i) in photos"
-        :key="photo.id"
-        class="tile"
-        type="button"
-        :aria-label="`Open photo ${startIndex + i + 1}`"
-        @click="$emit('open', startIndex + i)"
+      <div
+        v-for="(row, ri) in rows"
+        :key="ri"
+        class="wall-row"
+        :style="{ height: row.height + 'px' }"
       >
-        <img
-          class="tile__img"
-          :src="photo.images?.medium || photo.images?.large || photo.images?.full || ''"
-          :srcset="srcset(photo)"
-          sizes="(max-width: 480px) 50vw, (max-width: 1024px) 33vw, 22vw"
-          :width="photo.images?.width || undefined"
-          :height="photo.images?.height || undefined"
-          :alt="photo.images?.alt || ''"
-          :style="photo.id === morphId ? { viewTransitionName: 'ct-hero-photo' } : undefined"
-          loading="lazy"
-          decoding="async"
-        />
-        <span class="tile__overlay" aria-hidden="true">
-          <span v-if="photo.likeCount" class="tile__likes">♥ {{ photo.likeCount }}</span>
-        </span>
-      </button>
+        <button
+          v-for="cell in row.items"
+          :key="cell.photo.id"
+          class="tile"
+          type="button"
+          :style="{ width: cell.width + 'px' }"
+          :aria-label="`Open photo ${cell.index + 1}`"
+          @click="$emit('open', cell.index)"
+        >
+          <img
+            class="tile__img"
+            :src="cell.photo.images?.medium || cell.photo.images?.large || cell.photo.images?.full || ''"
+            :srcset="srcset(cell.photo)"
+            sizes="(max-width: 480px) 50vw, (max-width: 1024px) 33vw, 22vw"
+            :alt="cell.photo.images?.alt || ''"
+            :style="cell.photo.id === morphId ? { viewTransitionName: 'ct-hero-photo' } : undefined"
+            loading="lazy"
+            decoding="async"
+          />
+          <span class="tile__overlay" aria-hidden="true">
+            <span v-if="cell.photo.likeCount" class="tile__likes">♥ {{ cell.photo.likeCount }}</span>
+          </span>
+        </button>
+      </div>
     </template>
   </section>
 </template>
 
 <script setup lang="ts">
-// One chunk (~one page) of the wall. Self-virtualizes: when scrolled far from
-// the viewport it collapses to a spacer of its last measured height, so the
-// live DOM never holds more than the few sections near the viewport - the key
-// to rendering thousands of photos smoothly.
-import type { EventPhoto } from '~/types/event'
+// One windowed block of the wall: a run of pre-computed justified rows. When
+// scrolled far from the viewport it collapses to a spacer of its height, so the
+// live DOM never holds more than the few blocks near the viewport - the key to
+// rendering thousands of photos smoothly.
+//
+// The justified-rows layout is computed once in the parent (PhotoWall), which
+// knows the container width; each row is a flex line whose tiles are sized so
+// the row spans the full width edge-to-edge, in strict given order. The parent
+// also passes an estimated block height (estHeight) so a block that starts life
+// off-screen reserves the right space before it has ever been measured.
+import type { EventPhoto, WallRow } from '~/types/event'
 
 const props = defineProps<{
-  photos: EventPhoto[]
-  startIndex: number
+  rows: WallRow[]
+  estHeight: number
   morphId?: number | null
   darkroom?: boolean
 }>()
@@ -52,7 +64,15 @@ defineEmits<{ (e: 'open', index: number): void }>()
 
 const el = ref<HTMLElement | null>(null)
 const visible = ref(true) // render on first paint (SSR-friendly + measurable)
-const collapsedHeight = ref(0)
+const measured = ref(0)
+
+// While collapsed, hold the (measured, else estimated) height so scroll position
+// is preserved and an unseen block still reserves its space.
+const spacerStyle = computed(() => {
+  if (visible.value) return null
+  const h = measured.value || props.estHeight
+  return h ? { height: `${h}px` } : null
+})
 
 function srcset(photo: EventPhoto): string {
   const img = photo.images
@@ -63,7 +83,6 @@ function srcset(photo: EventPhoto): string {
   return parts.join(', ')
 }
 
-// Measure height before collapsing so the spacer preserves scroll position.
 useIntersectionObserver(
   el,
   ([entry]) => {
@@ -71,7 +90,7 @@ useIntersectionObserver(
       visible.value = true
     } else {
       if (el.value && visible.value) {
-        collapsedHeight.value = el.value.offsetHeight
+        measured.value = el.value.offsetHeight
       }
       visible.value = false
     }
@@ -82,28 +101,25 @@ useIntersectionObserver(
 
 <style scoped>
 .wall-section {
-  columns: 5 220px;
-  column-gap: 4px;
   padding: 0 2px;
 }
 
-@media (max-width: 1024px) {
-  .wall-section { columns: 3 200px; }
-}
-@media (max-width: 480px) {
-  .wall-section { columns: 2 140px; }
+.wall-row {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 4px;
 }
 
 .tile {
   display: block;
-  width: 100%;
-  margin: 0 0 4px;
+  height: 100%;
+  flex: 0 0 auto;
+  margin: 0;
   padding: 0;
   border: none;
   background: var(--color-surface);
   cursor: pointer;
   position: relative;
-  break-inside: avoid;
   overflow: hidden;
   /* Lift toward the viewer on hover: the tile itself scales up and rises above
      its neighbours (z-index), so the photo reads as coming forward rather than
@@ -125,7 +141,10 @@ useIntersectionObserver(
 .tile__img {
   display: block;
   width: 100%;
-  height: auto;
+  height: 100%;
+  /* Tiles are sized to each photo's exact aspect ratio, so cover trims nothing
+     visible - it just guarantees the row stays gap-free under sub-pixel rounding. */
+  object-fit: cover;
   border-radius: inherit;
   transition: transform 500ms ease, filter 300ms ease;
 }

--- a/frontend/types/event.ts
+++ b/frontend/types/event.ts
@@ -12,6 +12,12 @@ export interface EventPhoto {
   setSlug: string | null
 }
 
+/** One justified row of the photo wall: tiles share a height and span full width. */
+export interface WallRow {
+  height: number
+  items: { photo: EventPhoto; index: number; width: number }[]
+}
+
 export interface EventPhotoListResponse {
   photos: EventPhoto[]
   total: number


### PR DESCRIPTION
## What
Rebuilds the Cold Turkey photo wall grid from CSS multi-columns to a **justified-rows gallery**.

## Why
- **Order was wrong.** CSS `columns` filled top-to-bottom down each column, so the chronological sequence read #1,#11,#21… across the top row instead of #1,#2,#3. (Reported as "the math of the grid is not correct".)
- **Seams.** Each 50-photo section balanced its own columns, leaving ragged edges/uneven gaps every 50 photos.
- Request: "more masonry style and dynamic, sticking to current order."

## How
- Justified rows: walk photos in order, pack each row, scale it to span full width edge-to-edge. Strict order, no gaps, no seams.
- **Designed rhythm:** row target-heights vary on a deterministic pattern (periodic taller feature bands of fewer/bigger photos) so even all-landscape nights get a dynamic cadence; portrait-rich nights stagger naturally. Softened on narrow screens.
- Layout computed once in `PhotoWall` from the measured container width; `WallSection` keeps windowing, now with a deterministic off-screen height estimate.

## Verified (Playwright, against live data)
- Chronological order preserved; rows fill full width (1420/1421px); no gaps/seams.
- Dynamic on mixed nights (2011-09-04) **and** uniform nights (2012-03-18, feature bands of 3 @ 314px among rows of 4 @ 235px).
- Windowing bounds the DOM (~max 97 tiles after scrolling 400+); infinite-scroll paging intact; mobile (390px) clean 2-up.
- Build clean. The pre-existing hydration-mismatch warning is unchanged (present on current prod too; unrelated).