### PR TITLE
Article video: VideoEmbed component + lockfile resync

### DIFF
--- a/frontend/components/VideoEmbed.vue
+++ b/frontend/components/VideoEmbed.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { youTubeId } from '~/utils/youtube'
+
+// Click-to-load video embed. On page load nothing is requested from YouTube:
+// only a poster image (from i.ytimg.com) is shown behind a play button. The
+// nocookie player iframe is injected on the first click, so no third-party
+// player code runs until the visitor asks for it.
+const props = defineProps<{
+  url: string
+  title?: string
+}>()
+
+const playing = ref(false)
+const id = computed(() => youTubeId(props.url))
+
+// maxresdefault does not exist for every video; fall back to hqdefault on error.
+const poster = ref(id.value ? `https://i.ytimg.com/vi/${id.value}/maxresdefault.jpg` : '')
+const embed = computed(() =>
+  id.value ? `https://www.youtube-nocookie.com/embed/${id.value}?autoplay=1&rel=0` : '',
+)
+
+function posterFallback() {
+  if (id.value) poster.value = `https://i.ytimg.com/vi/${id.value}/hqdefault.jpg`
+}
+</script>
+
+<template>
+  <!-- Recognised YouTube URL: privacy facade + click-to-load nocookie player. -->
+  <figure v-if="id" class="video-embed">
+    <div class="video-embed__frame">
+      <button
+        v-if="!playing"
+        class="video-embed__facade"
+        type="button"
+        :aria-label="`Play video${title ? ': ' + title : ''}`"
+        @click="playing = true"
+      >
+        <img
+          class="video-embed__poster"
+          :src="poster"
+          :alt="title ?? ''"
+          loading="lazy"
+          @error="posterFallback"
+        >
+        <span class="video-embed__play" aria-hidden="true" />
+      </button>
+      <iframe
+        v-else
+        class="video-embed__iframe"
+        :src="embed"
+        :title="title ?? 'Embedded video player'"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allowfullscreen
+        loading="lazy"
+      />
+    </div>
+  </figure>
+
+  <!-- Any other provider: no facade, just a clear link so nothing breaks. -->
+  <p v-else-if="url" class="video-embed__fallback">
+    <a :href="url" target="_blank" rel="noopener noreferrer">
+      {{ title ? `Watch: ${title}` : 'Watch the video' }}
+    </a>
+  </p>
+</template>
+
+<style scoped>
+.video-embed {
+  margin: 2rem 0;
+}
+
+.video-embed__frame {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  background: #000;
+}
+
+.video-embed__iframe,
+.video-embed__facade {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.video-embed__facade {
+  padding: 0;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  background: #000;
+}
+
+.video-embed__poster {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.video-embed__play {
+  position: absolute;
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  display: grid;
+  place-items: center;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.video-embed__play::before {
+  content: "";
+  border-style: solid;
+  border-width: 0.75rem 0 0.75rem 1.25rem;
+  border-color: transparent transparent transparent #fff;
+  margin-left: 0.25rem;
+}
+
+.video-embed__facade:hover .video-embed__play,
+.video-embed__facade:focus-visible .video-embed__play {
+  transform: scale(1.08);
+  background: var(--color-accent);
+}
+
+.video-embed__facade:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.video-embed__fallback {
+  margin: 2rem 0;
+}
+
+.video-embed__fallback a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+</style>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -172,10 +172,12 @@ export default defineNuxtConfig({
           "script-src 'self' 'unsafe-inline' https://analytics.theazanianprepper.online https://w.soundcloud.com",
           "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
           "font-src 'self' https://fonts.gstatic.com",
+          // https: covers YouTube poster thumbnails from i.ytimg.com
           "img-src 'self' data: https:",
           "connect-src 'self' https://analytics.theazanianprepper.online",
-          // SoundCloud widget (Cold Turkey mix player on the photo wall)
-          "frame-src https://w.soundcloud.com",
+          // SoundCloud widget (Cold Turkey mix player); youtube-nocookie for the
+          // click-to-load VideoEmbed player on article pages
+          "frame-src https://w.soundcloud.com https://www.youtube-nocookie.com",
           "frame-ancestors 'none'",
           "base-uri 'self'",
           "form-action 'self'",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3507,9 +3507,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3525,9 +3522,6 @@
       "integrity": "sha512-3k8ezEKmxs9Wel4N4vfF/8u764mA57j065P8nB4cU2PO/lLKloN0OA41ynfDUrSM1f5jBuF8+mLOj++aNnu4OA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3545,9 +3539,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3563,9 +3554,6 @@
       "integrity": "sha512-KburrmtWpeZg58uo275QRwy5bbNOXQd1WDI2tGxkY2dJBlO7N5V9+Uthvqn6KI/6RBtjd2T5NO4dCC0fgUxGvw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3583,9 +3571,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3601,9 +3586,6 @@
       "integrity": "sha512-VE99UPZyQO2MAG4gLGXzrBumD5PGNaiWe+EakaROGCVbT0YH/d9z2ByYqbdWAMEBiTHjthyZp6UUEFVda+LnpQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3621,9 +3603,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3639,9 +3618,6 @@
       "integrity": "sha512-W8IqA2XRvg/b6l/f+2SdV45/KKmpmwTabrjiMtpg/wzJU5cmKUoHihtJXPc9NA0Ls9S/oP0wB3PMCRQoNr5J1A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3853,9 +3829,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3871,9 +3844,6 @@
       "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3891,9 +3861,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3909,9 +3876,6 @@
       "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3929,9 +3893,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3947,9 +3908,6 @@
       "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3967,9 +3925,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3985,9 +3940,6 @@
       "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4208,9 +4160,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4226,9 +4175,6 @@
       "integrity": "sha512-LxURDI0Wm2KCQm/3ynNlI+nTgPdfmAfmrl54XPx+gaIqty8S/XWNCCTvLJWaCb0e5eKqnzrcTuhMDOdawqoYIA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4246,9 +4192,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4264,9 +4207,6 @@
       "integrity": "sha512-Kz6tg1Msra7+2iGV8K5xANLO2SmpP6n+91/Yy+JJh9EagU4hvMm7loReszzz2bwhs6Xs4HPrglxIngMdqnHpXw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4284,9 +4224,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4302,9 +4239,6 @@
       "integrity": "sha512-9qVyCbYSs8dwVPpqKKWxuUAnLJ1+LyC5A4oNMZTzymRhuQr3coqAP/XWfJ8LlhQqI9GvhK0SWCOK0iM3HFUAnA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4322,9 +4256,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4340,9 +4271,6 @@
       "integrity": "sha512-I7BkkktnrriiO7o1dF3RDgKZoSmFKX9IE0W2LE1WdfmpZcAa3fbv5BW6oVbzk40iD29hWSP69A65WT9l6dxuzg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9689,6 +9617,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/devframe/node_modules/crossws": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.7.tgz",
+      "integrity": "sha512-N+BXE5AetLJ3/glz4DYLirKApAWg+V2guueoMenvAGVvqF/IA1PAzMYqYS+UfBkdz3tDXoQIevDaaxLy1Ch/4w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
       }
     },
     "node_modules/devframe/node_modules/h3": {

--- a/frontend/pages/writing/[slug].vue
+++ b/frontend/pages/writing/[slug].vue
@@ -36,6 +36,11 @@
         <img :src="post.coverImage.url" :alt="post.coverImage.alt || post.title" loading="eager">
       </figure>
 
+      <!-- Video from Drupal (field_video), near the top, breaks out to match the hero -->
+      <div v-if="post.videoUrl" class="post-video">
+        <VideoEmbed :url="post.videoUrl" :title="post.title" />
+      </div>
+
       <!-- Post body: Drupal provides sanitized HTML -->
       <!-- eslint-disable-next-line vue/no-v-html -->
       <article ref="bodyEl" class="post-body" v-html="post.body" />
@@ -122,6 +127,19 @@ useHead(() => ({
   display: block;
   border-radius: 8px;
   border: 1px solid var(--color-border);
+}
+
+/* Video breaks out to the same width as the featured image */
+.post-video {
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(1080px, 92vw);
+  margin: 0 0 3rem;
+}
+
+.post-video :deep(.video-embed) {
+  margin: 0;
 }
 
 .post-body {

--- a/frontend/server/api/drupal/blog/[slug].get.ts
+++ b/frontend/server/api/drupal/blog/[slug].get.ts
@@ -44,8 +44,13 @@ export default defineEventHandler(async (event) => {
 
   const nodeId = match.id
 
+  // field_video is a reference to a media--remote_video entity; ?include pulls
+  // that entity into `included`, where its field_media_oembed_video attribute
+  // carries the canonical watch URL (for example
+  // https://www.youtube.com/watch?v=…). Anonymous requests resolve it because
+  // the anonymous role holds the "view media" permission on Drupal.
   const data = await $fetch<any>(
-    `${base}/jsonapi/node/article/${nodeId}?include=field_tags,field_image`,
+    `${base}/jsonapi/node/article/${nodeId}?include=field_tags,field_image,field_video`,
     { headers: { Accept: 'application/vnd.api+json' } }
   ).catch(() => null)
 
@@ -71,7 +76,14 @@ function transformNode(node: any, included: any[]): DrupalBlogPost {
     coverImage,
     tags: resolveTags(node.relationships?.field_tags?.data ?? [], included),
     series: resolveSingleTerm(node.relationships?.field_series?.data, included),
+    videoUrl: resolveVideoUrl(node.relationships?.field_video?.data, included),
   }
+}
+
+function resolveVideoUrl(ref: any, included: any[]): string | undefined {
+  if (!ref) return undefined
+  const media = included.find((i: any) => i.type === ref.type && i.id === ref.id)
+  return media?.attributes?.field_media_oembed_video || undefined
 }
 
 function resolveImage(rel: any, included: any[]) {

--- a/frontend/types/drupal.ts
+++ b/frontend/types/drupal.ts
@@ -32,6 +32,9 @@ export interface DrupalBlogPost {
   coverImage?: DrupalImage
   tags: DrupalTag[]
   series?: DrupalTag
+  // Canonical oEmbed video URL from field_video (media--remote_video). Undefined
+  // when the article has no video. See server/api/drupal/blog/[slug].get.ts.
+  videoUrl?: string
 }
 
 export interface DrupalProject {

--- a/frontend/utils/youtube.ts
+++ b/frontend/utils/youtube.ts
@@ -1,0 +1,17 @@
+// Extract the 11-character YouTube video id from any common URL shape:
+// watch?v=, youtu.be/, embed/, youtube-nocookie.com/embed/. Stray query
+// params (for example ?si=, &t=) are ignored. Returns null for anything that
+// is not a recognised YouTube URL, so callers can degrade gracefully.
+export function youTubeId(url: string): string | null {
+  if (!url) return null
+  const patterns = [
+    /youtube\.com\/watch\?v=([\w-]{11})/,
+    /youtu\.be\/([\w-]{11})/,
+    /youtube(?:-nocookie)?\.com\/embed\/([\w-]{11})/,
+  ]
+  for (const re of patterns) {
+    const m = url.match(re)
+    if (m) return m[1]
+  }
+  return null
+}


### PR DESCRIPTION
## What
Renders article videos on the frontend from Drupal's `field_video` (now live on prod), and resyncs the lock file so the build passes.

## Changes
- **VideoEmbed** (`components/VideoEmbed.vue` + `utils/youtube.ts`): privacy-friendly click-to-load facade - poster (maxres→hqdefault fallback) behind a real `<button>`; injects the `youtube-nocookie` iframe with autoplay only on click; zero YouTube requests before interaction; 16:9 responsive; non-YouTube URLs degrade to a link.
- **Data**: `server/api/drupal/blog/[slug].get.ts` now `include=field_video` and exposes `field_media_oembed_video` as `videoUrl`; `types/drupal.ts` adds `videoUrl`.
- **Render**: `pages/writing/[slug].vue` renders `VideoEmbed` near the top (breaks out to hero width).
- **CSP**: `nuxt.config.ts` allows `www.youtube-nocookie.com` in `frame-src`.
- **Lockfile**: resync `package-lock.json` after the nuxt 3.21.8 bump re-desynced it (`crossws` missing), which was breaking every deploy.

## Verified
- Browser: facade fires zero YouTube requests on load; click loads the nocookie player and autoplays.
- `npm ci` in sync; `npm run build` completes.
- Backend already live: prod JSON:API returns `field_video` + `field_media_oembed_video` for the article anonymously.

## Follow-up
- Clean the article body (remove stray `watch?v=` line + chat-interface CSS cruft).