### PR TITLE
SEO: 301 www.madsnorgaard.net -> apex

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,20 @@ services:
       PHOTO_SITE_URL: https://photo.madsnorgaard.net
     container_name: madsnorgaard_nuxt
     labels:
-      - traefik.http.routers.madsnorgaard_nuxt.rule=Host(`madsnorgaard.net`) || Host(`www.madsnorgaard.net`)
+      - traefik.http.routers.madsnorgaard_nuxt.rule=Host(`madsnorgaard.net`)
       - traefik.http.routers.madsnorgaard_nuxt.tls=true
       - traefik.http.routers.madsnorgaard_nuxt.tls.certresolver=lets-encrypt
       - traefik.http.services.madsnorgaard_nuxt.loadbalancer.server.port=3000
+      # Canonicalise www -> apex with a 301 so the two hosts don't split ranking
+      # signals. $${1} (not ${1}) so compose doesn't eat it as a variable.
+      - traefik.http.routers.madsnorgaard_nuxt_www.rule=Host(`www.madsnorgaard.net`)
+      - traefik.http.routers.madsnorgaard_nuxt_www.tls=true
+      - traefik.http.routers.madsnorgaard_nuxt_www.tls.certresolver=lets-encrypt
+      - traefik.http.routers.madsnorgaard_nuxt_www.service=madsnorgaard_nuxt
+      - traefik.http.routers.madsnorgaard_nuxt_www.middlewares=madsnorgaard-www-redirect
+      - traefik.http.middlewares.madsnorgaard-www-redirect.redirectregex.regex=^https?://www\.madsnorgaard\.net/(.*)
+      - traefik.http.middlewares.madsnorgaard-www-redirect.redirectregex.replacement=https://madsnorgaard.net/$${1}
+      - traefik.http.middlewares.madsnorgaard-www-redirect.redirectregex.permanent=true
     networks:
       - web
       - drupalmadsnorgaardnet_internal


### PR DESCRIPTION
www and apex were both served by the same Traefik router with no redirect (duplicate host; only the canonical tag mitigated it). Split into two routers: apex serves, www gets a permanent `redirectregex` to the apex.

Note: `$${1}` in the replacement so docker-compose does not interpolate it as a variable (Traefik receives `${1}`).

## Verify after deploy
`curl -sI https://www.madsnorgaard.net/writing` -> `301` + `location: https://madsnorgaard.net/writing`