### PR TITLE
Retire legacy WordPress: docs + env cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,5 @@
-# Domain
-WORDPRESS_DOMAIN=madsnorgaard.net
-
-# WordPress / MySQL (kept running for photo.madsnorgaard.net data reference)
-MYSQL_ROOT_PASSWORD=change_me_root
-MYSQL_USER=wordpress
-MYSQL_PASSWORD=change_me_password
-MYSQL_DATABASE=wordpress
+# Legacy WordPress retired 2026-08-11 — archive (DB dump + wp-content) lives
+# at ~/archives/legacy-madsnorgaard-wp. Production WP is photo.madsnorgaard.net.
 
 # Nuxt frontend — reaches Drupal via internal Docker network (no public round-trip)
 DRUPAL_BASE_URL=http://madsnorgaard_drupal:80
@@ -15,3 +9,8 @@ GITHUB_TOKEN=ghp_your_token_here
 
 # Photo site URL (used by /api/status to fetch latest photo)
 PHOTO_SITE_URL=https://photo.madsnorgaard.net
+
+# Shared secret sent as X-Internal-Token on WP REST calls: bypasses the
+# photo-api-security per-IP rate limit and authorizes event-archive/v1 writes
+# (likes / guestbook). Must match the token configured on photo.madsnorgaard.net.
+PHOTO_API_INTERNAL_TOKEN=change_me_long_random

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Drupal 11 as the content API. photo.madsnorgaard.net as the photo story backend.
 - **Docker + Traefik v3** — routing, SSL, Let's Encrypt
 - **GitHub Actions** — CI/CD, builds Nuxt image and deploys to VPS2
 
+> The original madsnorgaard.net WordPress (this repo's pre-Nuxt era) was fully
+> retired on 2026-08-11: the local DDEV copy is stopped/unlisted and archived
+> (DB dump + wp-content) at `~/archives/legacy-madsnorgaard-wp`. The gitignored
+> `wp-*` files on disk can be deleted whenever.
+
 ## Setup
 
 ```bash

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -11,7 +11,10 @@ GITHUB_TOKEN=
 # Photo site public URL (used for WP REST API calls)
 PHOTO_SITE_URL=https://photo.madsnorgaard.net
 
-# madsnorgaard.net WordPress base URL (server-side only, for one-picture story)
-# DDEV local: http://madsnorgaard.net.ddev.site
-# Docker prod: http://madsnorgaard_wordpress (set in docker-compose.yml)
-WP_BASE_URL=http://madsnorgaard.net.ddev.site
+# Shared secret sent as X-Internal-Token on WP REST calls: bypasses the
+# photo-api-security per-IP rate limit and authorizes event-archive/v1 writes
+# (likes / guestbook). Must match the token configured on photo.madsnorgaard.net.
+PHOTO_API_INTERNAL_TOKEN=change_me_long_random
+
+# (Legacy WP_BASE_URL removed — the old madsnorgaard.net WordPress was retired
+# 2026-08-11; nothing reads it. Archive: ~/archives/legacy-madsnorgaard-wp)


### PR DESCRIPTION
Housekeeping from the WP security plan (Phase 6).

The legacy pre-Nuxt WordPress that lived at this repo's root (gitignored, local-DDEV-only) is now fully retired:
- DDEV project stopped + unlisted (`ddev list` no longer shows it)
- Final DB dump + 2.1G wp-content tarball archived at `~/archives/legacy-madsnorgaard-wp`, both verified
- Env examples cleaned: removed unused `MYSQL_*`/`WORDPRESS_DOMAIN`/`WP_BASE_URL` (verified nothing references them)
- **Documents `PHOTO_API_INTERNAL_TOKEN`** — previously undocumented despite being load-bearing for event likes/guestbook writes and the WP rate-limit bypass. Worth checking it's actually set in the production Nuxt container env.