### PR TITLE
Fix archive/portfolio category filters + Drupal image proxy + fonts CSP

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -140,6 +140,14 @@ export default defineNuxtConfig({
     // internally.
     '/one-picture-stories/**': { redirect: { to: '/', statusCode: 301 } },
     '/proj-cat/**': { redirect: { to: '/archive', statusCode: 301 } },
+
+    // Drupal article bodies reference inline images by their site-relative
+    // path (/sites/default/files/...), which only exists on the Drupal host —
+    // proxy them through so they load same-origin on the apex.
+    '/sites/default/files/**': {
+      proxy: 'https://drupal.madsnorgaard.net/sites/default/files/**',
+      swr: 86400,
+    },
     // /subject and /series have no photo-site equivalent (they 404 there): keep the
     // pages working but noindex them so they stop showing as thin, un-indexed duplicates.
     '/subject/**': { robots: false },
@@ -188,7 +196,10 @@ export default defineNuxtConfig({
           "font-src 'self' https://fonts.gstatic.com",
           // https: covers YouTube poster thumbnails from i.ytimg.com
           "img-src 'self' data: https:",
-          "connect-src 'self' https://analytics.theazanianprepper.online",
+          // fonts.googleapis.com: the browser preloads the fonts stylesheet
+          // as a fetch, which connect-src governs (style-src alone still
+          // logged a violation on every page).
+          "connect-src 'self' https://analytics.theazanianprepper.online https://fonts.googleapis.com",
           // SoundCloud widget (Cold Turkey mix player); youtube-nocookie for the
           // click-to-load VideoEmbed player on article pages
           "frame-src https://w.soundcloud.com https://www.youtube-nocookie.com",

--- a/frontend/pages/archive/index.vue
+++ b/frontend/pages/archive/index.vue
@@ -81,14 +81,9 @@ const { data } = await useFetch<any>('/api/wp/projects', {
   })),
 })
 
-// Collect unique categories from fetched projects
-const categories = computed(() => {
-  const map = new Map<string, { name: string; slug: string }>()
-  data.value?.projects?.forEach((p: any) =>
-    p.categories?.forEach((c: any) => map.set(c.slug, c))
-  )
-  return [...map.values()]
-})
+// Full category list so every pill stays visible while a filter is active
+const { data: catData } = await useFetch<any>('/api/wp/project-categories')
+const categories = computed(() => catData.value?.categories ?? [])
 
 function pageLink(page: number) {
   const q: Record<string, string> = { page: String(page) }

--- a/frontend/pages/proj/index.vue
+++ b/frontend/pages/proj/index.vue
@@ -80,14 +80,9 @@ const { data } = await useFetch<any>('/api/wp/projects', {
   })),
 })
 
-// Collect unique categories from fetched projects
-const categories = computed(() => {
-  const map = new Map<string, { name: string; slug: string }>()
-  data.value?.projects?.forEach((p: any) =>
-    p.categories?.forEach((c: any) => map.set(c.slug, c))
-  )
-  return [...map.values()]
-})
+// Full category list so every pill stays visible while a filter is active
+const { data: catData } = await useFetch<any>('/api/wp/project-categories')
+const categories = computed(() => catData.value?.categories ?? [])
 
 function pageLink(page: number) {
   const q: Record<string, string> = { page: String(page) }

--- a/frontend/server/api/wp/project-categories.get.ts
+++ b/frontend/server/api/wp/project-categories.get.ts
@@ -1,0 +1,22 @@
+// GET /api/wp/project-categories
+// Returns all non-empty project categories (project_cat taxonomy) used for
+// the filter pills on /archive and /proj. The taxonomy's REST base on the
+// WP side is "project-categories".
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+  const base = config.photoSiteUrl
+
+  const terms = await wpFetch<any[]>(
+    `${base}/wp-json/wp/v2/project-categories?per_page=50&hide_empty=true&orderby=count&order=desc&_fields=id,name,slug,count`
+  )
+
+  const categories = (Array.isArray(terms) ? terms : []).map((t) => ({
+    id: t.id,
+    name: decodeEntities(t.name ?? ''),
+    slug: t.slug ?? '',
+    count: t.count ?? 0,
+  }))
+
+  return { categories }
+})

--- a/frontend/server/api/wp/projects/index.get.ts
+++ b/frontend/server/api/wp/projects/index.get.ts
@@ -24,8 +24,14 @@ export default defineEventHandler(async (event) => {
     _embed: 'wp:featuredmedia,wp:term',
   })
 
+  // WP filters taxonomies by rest_base ("project-categories") and term ID,
+  // not by taxonomy name/slug - resolve the slug to its term ID first.
   if (query.project_cat && typeof query.project_cat === 'string' && isValidSlug(query.project_cat)) {
-    params.set('project_cat', query.project_cat)
+    const termId = await resolveProjectCat(base, query.project_cat)
+    if (!termId) {
+      return { projects: [], total: 0, totalPages: 0, page, perPage }
+    }
+    params.set('project-categories', String(termId))
   }
 
   const url = `${base}/wp-json/wp/v2/project?${params.toString()}`
@@ -35,6 +41,21 @@ export default defineEventHandler(async (event) => {
 
   return { projects, total, totalPages, page, perPage }
 })
+
+// slug -> term ID cache; terms are effectively static, avoid a WP roundtrip
+// on every filtered request.
+const catIdCache = new Map<string, number>()
+
+async function resolveProjectCat(base: string, slug: string): Promise<number | null> {
+  const cached = catIdCache.get(slug)
+  if (cached) return cached
+  const terms = await wpFetch<any[]>(
+    `${base}/wp-json/wp/v2/project-categories?slug=${encodeURIComponent(slug)}&_fields=id`
+  )
+  const id = Array.isArray(terms) && terms[0]?.id ? Number(terms[0].id) : null
+  if (id) catIdCache.set(slug, id)
+  return id
+}
 
 function toProject(post: any) {
   const media = post._embedded?.['wp:featuredmedia']?.[0]


### PR DESCRIPTION
## What

Three fixes from today's full-site Playwright audit ([report](https://claude.ai/code/artifact/a4b4da7c-e87b-418b-b75e-e1c0514f8b82)):

1. **Category filters on /archive and /proj did nothing.** The pills sent `project_cat=<slug>`, but WP REST filters the taxonomy by its rest_base `project-categories` and only accepts **term IDs** — the param was silently ignored, every category returned all 24 projects. The server route now resolves slug → term ID (cached); unknown slugs return an empty set. A new `/api/wp/project-categories` endpoint feeds the pills so all five categories stay visible while filtering.
2. **Inline images 404 on 5 writing posts** (7 images — Afrapix, Drupal 11, WSL, PayPal, SAHO posts). Drupal bodies reference `/sites/default/files/…` which only exists on the Drupal host; a Nitro proxy rule now serves it same-origin, cached a day.
3. **CSP violation logged on every page**: browsers preload the Google Fonts stylesheet as a fetch governed by `connect-src`; the host is now allowed.

## Verified

- Local dev: Events → 7, Portraits → 4, Commercial → 3 (matches taxonomy counts); correct pill highlighted; unknown slug → empty state.
- e2e suite: no regressions vs baseline; previously-failing `blog-images` spec now **passes**.
- After deploy, spot-check: `/archive?cat=events` shows 7 items, and images on `/writing/when-time-stands-still-afrapix-archives-living-digital-history` load.