### PR TITLE
Serve WP size variants with srcset instead of full-res originals

### DIFF
--- a/frontend/components/OnePictureStory.vue
+++ b/frontend/components/OnePictureStory.vue
@@ -7,15 +7,12 @@
       aria-label="Toggle story caption"
       @click="captionOpen = !captionOpen"
     >
-      <img
+      <WpImage
         v-if="current.image"
-        :src="current.image.src"
-        :alt="current.image.alt"
-        :width="current.image.width ?? undefined"
-        :height="current.image.height ?? undefined"
+        :image="current.image"
+        sizes="(max-width: 900px) 100vw, 640px"
         class="ops__image"
         :class="{ 'ops__image--fading': fading }"
-        loading="lazy"
       />
 
       <!-- Caption overlay -->
@@ -39,6 +36,8 @@
 </template>
 
 <script setup lang="ts">
+import type { FeaturedImage } from '~/types/photo'
+
 type Story = {
   id: number
   title: string
@@ -46,7 +45,7 @@ type Story = {
   date: string
   slug: string
   url: string
-  image: { src: string; alt: string; width: number | null; height: number | null } | null
+  image: FeaturedImage | null
 }
 
 const props = defineProps<{

--- a/frontend/components/PostCard.vue
+++ b/frontend/components/PostCard.vue
@@ -13,11 +13,11 @@
     <!-- Front face -->
     <div class="post-card-flip__face post-card-flip__front">
       <div class="post-card-flip__image">
-        <img
+        <WpImage
           v-if="post.featuredImage?.src"
-          :src="post.featuredImage.src"
-          :alt="post.featuredImage.alt"
-          loading="lazy"
+          :image="post.featuredImage"
+          :max-width="768"
+          sizes="(max-width: 640px) 100vw, 33vw"
         />
       </div>
       <div class="post-card-flip__body">
@@ -55,6 +55,8 @@
 </template>
 
 <script setup lang="ts">
+import type { FeaturedImage } from '~/types/photo'
+
 defineProps<{
   post: {
     id: number
@@ -62,7 +64,7 @@ defineProps<{
     slug: string
     date: string
     excerpt: string
-    featuredImage: { src: string | null; alt: string } | null
+    featuredImage: FeaturedImage | null
     categories: { id: number; name: string; slug: string }[]
     tags: { id: number; name: string; slug: string }[]
   }

--- a/frontend/components/WpImage.vue
+++ b/frontend/components/WpImage.vue
@@ -1,0 +1,51 @@
+<template>
+  <img
+    v-if="resolved.src"
+    :src="resolved.src"
+    :srcset="resolved.srcset"
+    :sizes="resolved.srcset ? sizes : undefined"
+    :alt="alt ?? imageAlt"
+    :width="resolved.width"
+    :height="resolved.height"
+    :loading="eager ? 'eager' : 'lazy'"
+    :fetchpriority="eager ? 'high' : undefined"
+    decoding="async"
+  />
+</template>
+
+<script setup lang="ts">
+// Renders a WP image from its API `images`/`featuredImage` object with a
+// srcset built from the size variants that actually exist for that upload.
+// Degrades to a single flat-field src when `variants` is absent (payloads
+// cached before the field existed).
+import type { PhotoImages, FeaturedImage } from '~/types/photo'
+import { buildSrcset, fallbackSrc } from '~/utils/wp-srcset'
+
+const props = withDefaults(
+  defineProps<{
+    image: PhotoImages | FeaturedImage | null | undefined
+    /** Rendered slot width, e.g. "(max-width: 640px) 100vw, 33vw". */
+    sizes?: string
+    /** Cap srcset candidates (grids: 1024/768); omit for heroes/lightbox. */
+    maxWidth?: number
+    /** Above-the-fold: eager + fetchpriority=high. */
+    eager?: boolean
+    alt?: string
+  }>(),
+  { sizes: '100vw' },
+)
+
+const imageAlt = computed(() => (props.image as any)?.alt ?? '')
+
+const resolved = computed(() => {
+  const built = buildSrcset((props.image as any)?.variants, props.maxWidth)
+  if (built) return built
+  const p = props.image as any
+  return {
+    src: fallbackSrc(props.image, props.maxWidth && props.maxWidth <= 1024 ? 'small' : 'large'),
+    srcset: undefined as string | undefined,
+    width: p?.width ?? undefined,
+    height: p?.height ?? undefined,
+  }
+})
+</script>

--- a/frontend/components/event/EventHero.vue
+++ b/frontend/components/event/EventHero.vue
@@ -5,11 +5,14 @@
     <div class="hero__drift" aria-hidden="true">
       <div class="hero__track">
         <img
-          v-for="(src, i) in doubled"
+          v-for="(thumb, i) in doubled"
           :key="i"
-          :src="src"
+          :src="thumb.src"
+          :srcset="thumb.srcset"
+          :sizes="thumb.srcset ? '(max-width: 640px) 39vh, 57vh' : undefined"
           alt=""
-          loading="eager"
+          :loading="i < 5 ? 'eager' : 'lazy'"
+          :fetchpriority="i < 2 ? 'high' : undefined"
           decoding="async"
           class="hero__thumb"
         />
@@ -34,15 +37,25 @@
 </template>
 
 <script setup lang="ts">
+import type { PhotoImages } from '~/types/photo'
+import { buildSrcset, fallbackSrc } from '~/utils/wp-srcset'
+
 const props = defineProps<{
-  thumbs: string[]
+  thumbs: PhotoImages[]
 }>()
 
 defineEmits<{ (e: 'enter'): void }>()
 
-// Duplicate the strip so the marquee loops seamlessly.
+// Duplicate the strip so the marquee loops seamlessly. The 38vh frames never
+// need more than a 768px file; the second (duplicated) half starts off-screen
+// and the marquee takes 45s to reach it, so it always lazy-loads.
 const doubled = computed(() => {
-  const t = props.thumbs.slice(0, 20)
+  const t = props.thumbs.slice(0, 20).map((images) => {
+    const built = buildSrcset(images.variants, 768)
+    return built
+      ? { src: built.src, srcset: built.srcset }
+      : { src: fallbackSrc(images, 'small'), srcset: undefined }
+  })
   return t.length ? [...t, ...t] : []
 })
 </script>

--- a/frontend/components/event/FavContactSheet.vue
+++ b/frontend/components/event/FavContactSheet.vue
@@ -15,9 +15,12 @@
       <figure v-for="(photo, i) in photos" :key="photo.id" class="frame">
         <img
           class="frame__img"
-          :src="photo.images?.medium || photo.images?.large || ''"
+          :src="tileAttrs(photo).src"
+          :srcset="tileAttrs(photo).srcset"
+          :sizes="tileAttrs(photo).srcset ? '(max-width: 640px) 45vw, 240px' : undefined"
           :alt="photo.images?.alt || ''"
           loading="lazy"
+          decoding="async"
         />
         <figcaption class="frame__no">{{ String(i + 1).padStart(2, '0') }}</figcaption>
       </figure>
@@ -30,6 +33,12 @@ import type { EventPhoto } from '~/types/event'
 
 defineProps<{ photos: EventPhoto[] }>()
 defineEmits<{ (e: 'close'): void }>()
+
+function tileAttrs(photo: EventPhoto): { src: string; srcset?: string } {
+  const built = buildSrcset(photo.images?.variants, 768)
+  if (built) return built
+  return { src: fallbackSrc(photo.images, 'small'), srcset: undefined }
+}
 
 function print() {
   window.print()

--- a/frontend/components/event/TopPicks.vue
+++ b/frontend/components/event/TopPicks.vue
@@ -14,7 +14,9 @@
         >
           <img
             class="toppicks__img"
-            :src="p.images?.medium || p.images?.thumbnail || p.images?.large || ''"
+            :src="tileAttrs(p).src"
+            :srcset="tileAttrs(p).srcset"
+            :sizes="tileAttrs(p).srcset ? '144px' : undefined"
             :alt="p.images?.alt || 'Cold Turkey Cape Town photograph'"
             loading="lazy"
             decoding="async"
@@ -35,6 +37,12 @@ const { data } = await useAsyncData('ctct-top', () =>
   $fetch('/api/event/top', { query: { count: 12 } }),
 )
 const picks = computed<EventPhoto[]>(() => (data.value as any)?.photos ?? [])
+
+function tileAttrs(photo: EventPhoto): { src: string; srcset?: string } {
+  const built = buildSrcset(photo.images?.variants, 300)
+  if (built) return built
+  return { src: fallbackSrc(photo.images, 'small'), srcset: undefined }
+}
 </script>
 
 <style scoped>

--- a/frontend/components/event/WallSection.vue
+++ b/frontend/components/event/WallSection.vue
@@ -23,8 +23,8 @@
         >
           <img
             class="tile__img"
-            :src="cell.photo.images?.medium || cell.photo.images?.large || cell.photo.images?.full || ''"
-            :srcset="srcset(cell.photo)"
+            :src="tileAttrs(cell.photo).src"
+            :srcset="tileAttrs(cell.photo).srcset"
             sizes="(max-width: 480px) 50vw, (max-width: 1024px) 33vw, 22vw"
             :alt="cell.photo.images?.alt || ''"
             :style="cell.photo.id === morphId ? { viewTransitionName: 'ct-hero-photo' } : undefined"
@@ -74,13 +74,13 @@ const spacerStyle = computed(() => {
   return h ? { height: `${h}px` } : null
 })
 
-function srcset(photo: EventPhoto): string {
-  const img = photo.images
-  if (!img) return ''
-  const parts: string[] = []
-  if (img.medium) parts.push(`${img.medium} 300w`)
-  if (img.large) parts.push(`${img.large} 1024w`)
-  return parts.join(', ')
+// True width descriptors from the per-image variants (300/768/1024), so the
+// browser stops over-fetching `large` for every tile. Falls back to the flat
+// fields for payloads cached before `variants` existed.
+function tileAttrs(photo: EventPhoto): { src: string; srcset?: string } {
+  const built = buildSrcset(photo.images?.variants, 1024)
+  if (built) return built
+  return { src: fallbackSrc(photo.images, 'small'), srcset: undefined }
 }
 
 useIntersectionObserver(

--- a/frontend/components/photo/PhotoLightbox.vue
+++ b/frontend/components/photo/PhotoLightbox.vue
@@ -31,6 +31,8 @@
             <img
               :key="reel ? index : undefined"
               :src="current?.src ?? ''"
+              :srcset="current?.srcset || undefined"
+              :sizes="current?.srcset ? '92vw' : undefined"
               :alt="current?.alt ?? ''"
               class="lightbox__image"
               :class="{ 'lightbox__image--kenburns': reel, 'lightbox__image--nav': images.length > 1 }"
@@ -79,6 +81,8 @@
 
 export interface LightboxImage {
   src: string
+  /** Optional responsive candidates spanning up to the original. */
+  srcset?: string
   alt?: string
   width?: string | number | null
   height?: string | number | null

--- a/frontend/components/projects/ProjectCard.vue
+++ b/frontend/components/projects/ProjectCard.vue
@@ -13,7 +13,7 @@
     <!-- Front face -->
     <div class="project-card__face project-card__front">
       <div v-if="project.coverImage" class="project-card__image">
-        <img :src="project.coverImage.url" :alt="project.coverImage.alt || project.title" loading="lazy" />
+        <img :src="project.coverImage.url" :alt="project.coverImage.alt || project.title" loading="lazy" decoding="async" />
       </div>
       <div v-else class="project-card__image project-card__image--placeholder">
         <svg :id="`proj-bg-${project.id}`" viewBox="0 0 300 200"

--- a/frontend/components/story/PhotoEmbed.vue
+++ b/frontend/components/story/PhotoEmbed.vue
@@ -2,12 +2,15 @@
   <figure v-if="photo" :class="['photo-embed', alignClass]">
     <NuxtLink :to="`/archive/${photo.slug}`" class="photo-embed__link">
       <img
-        v-if="imageSrc"
-        :src="imageSrc"
+        v-if="imageAttrs"
+        :src="imageAttrs.src"
+        :srcset="imageAttrs.srcset"
+        :sizes="imageAttrs.srcset ? sizesAttr : undefined"
         :alt="photo.title"
-        :width="imageWidth"
-        :height="imageHeight"
+        :width="imageAttrs.width"
+        :height="imageAttrs.height"
         loading="lazy"
+        decoding="async"
         class="photo-embed__image"
       />
     </NuxtLink>
@@ -31,20 +34,17 @@ const alignClass = computed(() =>
   props.alignment !== 'none' ? `photo-embed--${props.alignment}` : ''
 )
 
-const imageSrc = computed(() => {
-  if (!props.photo?.images) return null
-  return props.photo.images.large?.url
-    ?? props.photo.images.full?.url
-    ?? props.photo.images.medium?.url
-    ?? null
-})
-
-const imageWidth = computed(() =>
-  props.photo?.images?.large?.width ?? props.photo?.images?.full?.width ?? undefined
+const imageAttrs = computed(() =>
+  buildSrcset(variantsFromResolved(props.photo?.images), 2048)
 )
 
-const imageHeight = computed(() =>
-  props.photo?.images?.large?.height ?? props.photo?.images?.full?.height ?? undefined
+// Wide/full alignments break out of the 42rem reading column.
+const sizesAttr = computed(() =>
+  props.alignment === 'wide' || props.alignment === 'full'
+    ? '100vw'
+    : props.alignment === 'left' || props.alignment === 'right'
+      ? '(max-width: 719px) 100vw, 320px'
+      : '(max-width: 719px) 100vw, 672px'
 )
 </script>
 

--- a/frontend/components/story/PhotoSequence.vue
+++ b/frontend/components/story/PhotoSequence.vue
@@ -8,10 +8,15 @@
       >
         <NuxtLink :to="`/archive/${photo.slug}`" class="photo-sequence__link">
           <img
-            v-if="getImageUrl(photo)"
-            :src="getImageUrl(photo)!"
+            v-if="getImageAttrs(photo)"
+            :src="getImageAttrs(photo)!.src"
+            :srcset="getImageAttrs(photo)!.srcset"
+            :sizes="getImageAttrs(photo)!.srcset ? '(max-width: 500px) 80vw, 400px' : undefined"
             :alt="photo.title"
+            :width="getImageAttrs(photo)!.width"
+            :height="getImageAttrs(photo)!.height"
             loading="lazy"
+            decoding="async"
             class="photo-sequence__image"
           />
         </NuxtLink>
@@ -40,11 +45,8 @@ const photos = computed(() =>
     .filter((p): p is ResolvedPhoto => !!p)
 )
 
-function getImageUrl(photo: ResolvedPhoto): string | null {
-  return photo.images?.medium?.url
-    ?? photo.images?.large?.url
-    ?? photo.images?.full?.url
-    ?? null
+function getImageAttrs(photo: ResolvedPhoto) {
+  return buildSrcset(variantsFromResolved(photo.images), 1024)
 }
 </script>
 

--- a/frontend/composables/useHeroPreload.ts
+++ b/frontend/composables/useHeroPreload.ts
@@ -1,0 +1,26 @@
+import type { PhotoImages, FeaturedImage } from '~/types/photo'
+import { buildSrcset } from '~/utils/wp-srcset'
+
+/**
+ * Preload the LCP hero image with the same srcset the <img> uses, so the
+ * browser starts fetching the right candidate before render.
+ */
+export function useHeroPreload(
+  image: PhotoImages | FeaturedImage | null | undefined,
+  sizes = '100vw',
+) {
+  const built = buildSrcset((image as any)?.variants)
+  if (!built?.src) return
+  useHead({
+    link: [
+      {
+        rel: 'preload',
+        as: 'image',
+        href: built.src,
+        imagesrcset: built.srcset,
+        imagesizes: built.srcset ? sizes : undefined,
+        fetchpriority: 'high',
+      },
+    ],
+  })
+}

--- a/frontend/pages/archive/[slug].vue
+++ b/frontend/pages/archive/[slug].vue
@@ -2,14 +2,13 @@
   <div v-if="photo" class="container" style="padding-top: 4rem;">
     <!-- Hero image -->
     <div class="photo-detail__hero">
-      <img
+      <WpImage
         v-if="photo.images?.full || photo.images?.large"
-        :src="(photo.images.full || photo.images.large)!"
+        :image="photo.images"
+        eager
+        sizes="100vw"
         :alt="photo.title"
-        :width="photo.images?.width ?? undefined"
-        :height="photo.images?.height ?? undefined"
         class="photo-detail__image"
-        loading="eager"
       />
     </div>
 
@@ -67,6 +66,8 @@ import type { Photo } from '~/types/photo'
 
 const route = useRoute()
 const { data: photo } = await useFetch<Photo>(`/api/photo/${route.params.slug}`)
+
+useHeroPreload(photo.value?.images)
 
 if (!photo.value) {
   throw createError({ statusCode: 404, statusMessage: 'Photo not found' })

--- a/frontend/pages/archive/index.vue
+++ b/frontend/pages/archive/index.vue
@@ -30,11 +30,11 @@
         class="collection-grid__item"
       >
         <div class="collection-grid__image-wrap">
-          <img
+          <WpImage
             v-if="project.featuredImage?.src"
-            :src="project.featuredImage.src"
-            :alt="project.featuredImage.alt"
-            loading="lazy"
+            :image="project.featuredImage"
+            :max-width="1024"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             class="collection-grid__image"
           />
         </div>

--- a/frontend/pages/category/[slug].vue
+++ b/frontend/pages/category/[slug].vue
@@ -12,7 +12,7 @@
     <section v-if="data.posts?.length" class="posts-list">
       <article v-for="post in data.posts" :key="post.id" class="post-card">
         <NuxtLink v-if="post.featuredImage?.src" :to="`/post/${post.slug}`" class="post-card__thumb">
-          <img :src="post.featuredImage.src" :alt="post.featuredImage.alt" loading="lazy" class="post-card__image" />
+          <WpImage :image="post.featuredImage" :max-width="768" sizes="(max-width: 640px) 100vw, 200px" class="post-card__image" />
         </NuxtLink>
         <div class="post-card__body">
           <h2 class="post-card__title">

--- a/frontend/pages/photographs/cold-turkey-cape-town.vue
+++ b/frontend/pages/photographs/cold-turkey-cape-town.vue
@@ -244,7 +244,7 @@ const activeList = computed<EventPhoto[]>(() =>
 )
 
 const heroThumbs = computed(() =>
-  photos.value.slice(0, 20).map((p) => p.images?.medium || p.images?.large || '').filter(Boolean)
+  photos.value.slice(0, 20).map((p) => p.images).filter((i): i is NonNullable<typeof i> => !!i)
 )
 
 async function loadMore() {
@@ -290,13 +290,19 @@ const lightboxPhotos = computed<EventPhoto[]>(() =>
 )
 
 const lightboxImages = computed<LightboxImage[]>(() =>
-  lightboxPhotos.value.map((p) => ({
-    src: p.images?.large || p.images?.full || p.images?.medium || '',
-    alt: p.images?.alt || '',
-    width: p.images?.width ?? null,
-    height: p.images?.height ?? null,
-    id: p.id,
-  }))
+  lightboxPhotos.value.map((p) => {
+    // Uncapped: the srcset spans to the original so big retina screens keep
+    // full sharpness while laptops fetch the 1024/1536 candidate.
+    const built = buildSrcset(p.images?.variants)
+    return {
+      src: built?.src ?? (p.images?.large || p.images?.full || p.images?.medium || ''),
+      srcset: built?.srcset,
+      alt: p.images?.alt || '',
+      width: p.images?.width ?? null,
+      height: p.images?.height ?? null,
+      id: p.id,
+    }
+  })
 )
 
 const currentPhoto = computed<EventPhoto | null>(

--- a/frontend/pages/post/[slug].vue
+++ b/frontend/pages/post/[slug].vue
@@ -2,13 +2,11 @@
   <article v-if="post" class="post-page">
     <!-- Hero image (full-bleed) -->
     <div v-if="post.featuredImage?.src" class="post-page__hero">
-      <img
-        :src="post.featuredImage.src"
-        :alt="post.featuredImage.alt"
-        :width="post.featuredImage.width ?? undefined"
-        :height="post.featuredImage.height ?? undefined"
+      <WpImage
+        :image="post.featuredImage"
+        eager
+        sizes="100vw"
         class="post-page__image"
-        loading="eager"
       />
     </div>
 
@@ -65,6 +63,8 @@
 <script setup lang="ts">
 const route = useRoute()
 const { data: post } = await useFetch<any>(`/api/wp/posts/${route.params.slug}`)
+
+useHeroPreload(post.value?.featuredImage)
 
 if (!post.value) {
   throw createError({ statusCode: 404, statusMessage: 'Post not found' })

--- a/frontend/pages/proj/[slug].vue
+++ b/frontend/pages/proj/[slug].vue
@@ -59,8 +59,11 @@
         >
           <img
             :src="block.image.src"
+            :srcset="block.image.srcset || undefined"
+            :sizes="block.image.srcset ? '(max-width: 719px) 100vw, 640px' : undefined"
             :alt="block.image.alt"
             loading="lazy"
+            decoding="async"
             class="project-detail__single-img"
           />
         </figure>
@@ -76,7 +79,15 @@
             class="composite__item"
             @click="openLightbox(block.startIndex + j)"
           >
-            <img :src="img.src" :alt="img.alt" loading="lazy" class="composite__image" />
+            <img
+              :src="img.src"
+              :srcset="img.srcset || undefined"
+              :sizes="img.srcset ? '(max-width: 719px) 33vw, 213px' : undefined"
+              :alt="img.alt"
+              loading="lazy"
+              decoding="async"
+              class="composite__image"
+            />
           </div>
         </div>
 
@@ -91,7 +102,15 @@
             class="gallery__item"
             @click="openLightbox(block.startIndex + j)"
           >
-            <img :src="img.src" :alt="img.alt" loading="lazy" class="gallery__image" />
+            <img
+              :src="img.src"
+              :srcset="img.srcset || undefined"
+              :sizes="img.srcset ? '(max-width: 480px) 100vw, (max-width: 768px) 50vw, 33vw' : undefined"
+              :alt="img.alt"
+              loading="lazy"
+              decoding="async"
+              class="gallery__image"
+            />
           </div>
         </div>
       </template>
@@ -105,7 +124,7 @@
 
     <!-- Lightbox overlay (shared component) -->
     <PhotoLightbox
-      :images="parsed.allImages"
+      :images="lightboxImages"
       v-model:index="lightbox.index"
       v-model:active="lightbox.active"
     />
@@ -125,7 +144,12 @@ if (!project.value) {
 // ─── Content types ──────────────────────────────────────────────
 
 interface GalleryImage {
+  /** Tile display source: the sized <img> from WP content, not the link target. */
   src: string
+  /** WP-generated responsive candidates carried through from content ('' if none). */
+  srcset: string
+  /** The original file (gallery <a href>), shown in the lightbox. */
+  full: string
   alt: string
   width: string
   height: string
@@ -165,10 +189,16 @@ const parsed = computed<{ blocks: ContentBlock[]; allImages: GalleryImage[] }>((
       const link = img.closest('a')
       const linkHref = link?.getAttribute('href') || ''
       const isImageUrl = /\.(jpe?g|png|gif|webp)(\?.*)?$/i.test(linkHref)
-      const src = isImageUrl ? linkHref : imgSrc
       const size = link?.getAttribute('data-size') || ''
       const [w, h] = size ? size.split('x') : ['', '']
-      imgs.push({ src, alt: img.getAttribute('alt') || '', width: w || '', height: h || '' })
+      imgs.push({
+        src: imgSrc,
+        srcset: img.getAttribute('srcset') || '',
+        full: isImageUrl ? linkHref : imgSrc,
+        alt: img.getAttribute('alt') || '',
+        width: w || '',
+        height: h || '',
+      })
     })
     return imgs
   }
@@ -229,6 +259,18 @@ const lightbox = reactive({
   active: false,
   index: 0,
 })
+
+// Lightbox gets the original file; srcset lets the browser fetch a smaller
+// candidate when the viewport doesn't need full resolution.
+const lightboxImages = computed(() =>
+  parsed.value.allImages.map(img => ({
+    src: img.full,
+    srcset: img.srcset || undefined,
+    alt: img.alt,
+    width: img.width,
+    height: img.height,
+  }))
+)
 
 function openLightbox(index: number) {
   lightbox.index = index

--- a/frontend/pages/proj/index.vue
+++ b/frontend/pages/proj/index.vue
@@ -30,10 +30,10 @@
         class="project-grid__item"
       >
         <div v-if="project.featuredImage?.src" class="project-grid__image-wrap">
-          <img
-            :src="project.featuredImage.src"
-            :alt="project.featuredImage.alt"
-            loading="lazy"
+          <WpImage
+            :image="project.featuredImage"
+            :max-width="1024"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             class="project-grid__image"
           />
         </div>

--- a/frontend/pages/series/[slug].vue
+++ b/frontend/pages/series/[slug].vue
@@ -14,7 +14,7 @@
         <article v-for="story in data.stories" :key="story.id" class="story-card">
           <NuxtLink :to="`/stories/${story.slug}`" class="story-card__link">
             <div v-if="story.featuredImage?.src" class="story-card__thumb">
-              <img :src="story.featuredImage.src" :alt="story.featuredImage.alt" loading="lazy" class="story-card__image" />
+              <WpImage :image="story.featuredImage" :max-width="768" sizes="(max-width: 640px) 100vw, 200px" class="story-card__image" />
             </div>
             <div>
               <h3 class="story-card__title">{{ story.title }}</h3>
@@ -37,11 +37,12 @@
           :to="`/archive/${photo.slug}`"
           class="photo-grid__item"
         >
-          <img
+          <WpImage
             v-if="photo.images?.medium || photo.images?.large"
-            :src="(photo.images.medium || photo.images.large)!"
+            :image="photo.images"
+            :max-width="1024"
+            sizes="(max-width: 640px) 50vw, 33vw"
             :alt="photo.title"
-            loading="lazy"
             class="photo-grid__image"
           />
           <div class="photo-grid__overlay">

--- a/frontend/pages/stories/[slug].vue
+++ b/frontend/pages/stories/[slug].vue
@@ -19,13 +19,11 @@
 
     <!-- Featured image (full-bleed) -->
     <div v-if="story.featuredImage?.src" class="story-page__featured">
-      <img
-        :src="story.featuredImage.src"
-        :alt="story.featuredImage.alt"
-        :width="story.featuredImage.width ?? undefined"
-        :height="story.featuredImage.height ?? undefined"
+      <WpImage
+        :image="story.featuredImage"
+        eager
+        sizes="100vw"
         class="story-page__featured-image"
-        loading="eager"
       />
     </div>
 
@@ -71,6 +69,8 @@ const { data: story } = await useFetch<Story>(`/api/wp/stories/${route.params.sl
 if (!story.value) {
   throw createError({ statusCode: 404, statusMessage: 'Story not found' })
 }
+
+useHeroPreload(story.value?.featuredImage)
 
 const pageTitle = story.value?.title || 'Stories'
 const pageDesc = story.value?.excerpt || `${pageTitle} - a documentary photo essay`

--- a/frontend/pages/stories/index.vue
+++ b/frontend/pages/stories/index.vue
@@ -13,10 +13,10 @@
       >
         <NuxtLink :to="`/stories/${story.slug}`" class="story-card__link">
           <div v-if="story.featuredImage?.src" class="story-card__image-wrap">
-            <img
-              :src="story.featuredImage.src"
-              :alt="story.featuredImage.alt"
-              loading="lazy"
+            <WpImage
+              :image="story.featuredImage"
+              :max-width="768"
+              sizes="(max-width: 640px) 100vw, 200px"
               class="story-card__image"
             />
           </div>

--- a/frontend/pages/subject/[slug].vue
+++ b/frontend/pages/subject/[slug].vue
@@ -14,7 +14,7 @@
         <article v-for="story in data.stories" :key="story.id" class="story-card">
           <NuxtLink :to="`/stories/${story.slug}`" class="story-card__link">
             <div v-if="story.featuredImage?.src" class="story-card__thumb">
-              <img :src="story.featuredImage.src" :alt="story.featuredImage.alt" loading="lazy" class="story-card__image" />
+              <WpImage :image="story.featuredImage" :max-width="768" sizes="(max-width: 640px) 100vw, 200px" class="story-card__image" />
             </div>
             <div>
               <h3 class="story-card__title">{{ story.title }}</h3>
@@ -37,11 +37,12 @@
           :to="`/archive/${photo.slug}`"
           class="photo-grid__item"
         >
-          <img
+          <WpImage
             v-if="photo.images?.medium || photo.images?.large"
-            :src="(photo.images.medium || photo.images.large)!"
+            :image="photo.images"
+            :max-width="1024"
+            sizes="(max-width: 640px) 50vw, 33vw"
             :alt="photo.title"
-            loading="lazy"
             class="photo-grid__image"
           />
           <div class="photo-grid__overlay">

--- a/frontend/pages/tag/[slug].vue
+++ b/frontend/pages/tag/[slug].vue
@@ -12,7 +12,7 @@
     <section v-if="data.posts?.length" class="posts-list">
       <article v-for="post in data.posts" :key="post.id" class="post-card">
         <NuxtLink v-if="post.featuredImage?.src" :to="`/post/${post.slug}`" class="post-card__thumb">
-          <img :src="post.featuredImage.src" :alt="post.featuredImage.alt" loading="lazy" class="post-card__image" />
+          <WpImage :image="post.featuredImage" :max-width="768" sizes="(max-width: 640px) 100vw, 200px" class="post-card__image" />
         </NuxtLink>
         <div class="post-card__body">
           <h2 class="post-card__title">

--- a/frontend/pages/writing/[slug].vue
+++ b/frontend/pages/writing/[slug].vue
@@ -33,7 +33,7 @@
 
       <!-- Featured image from Drupal (field_image), breaks out wider than the text -->
       <figure v-if="post.coverImage?.url" class="post-hero">
-        <img :src="post.coverImage.url" :alt="post.coverImage.alt || post.title" loading="eager">
+        <img :src="post.coverImage.url" :alt="post.coverImage.alt || post.title" loading="eager" fetchpriority="high" decoding="async">
       </figure>
 
       <!-- Video from Drupal (field_video), near the top, breaks out to match the hero -->

--- a/frontend/server/api/event/photo/[id].get.ts
+++ b/frontend/server/api/event/photo/[id].get.ts
@@ -25,7 +25,7 @@ export default defineEventHandler(async (event) => {
 
   return {
     id: post.id,
-    images: extractImages(media),
+    images: extractWpImages(media),
     likeCount: Number(post.meta?.like_count ?? 0),
     thereCount: Number(post.meta?.there_count ?? 0),
     captureDate: post.meta?.capture_date || null,
@@ -33,17 +33,3 @@ export default defineEventHandler(async (event) => {
     setName: night ? decodeEntities(night.name ?? '') : null,
   }
 })
-
-function extractImages(media: any) {
-  if (!media) return null
-  const sizes = media.media_details?.sizes ?? {}
-  return {
-    thumbnail: sizes.thumbnail?.source_url ?? null,
-    medium: sizes.medium?.source_url ?? sizes.medium_large?.source_url ?? null,
-    large: sizes.large?.source_url ?? null,
-    full: media.source_url ?? null,
-    width: media.media_details?.width ?? null,
-    height: media.media_details?.height ?? null,
-    alt: media.alt_text || '',
-  }
-}

--- a/frontend/server/api/event/photos/index.get.ts
+++ b/frontend/server/api/event/photos/index.get.ts
@@ -84,24 +84,10 @@ function toEventPhoto(post: any) {
 
   return {
     id: post.id,
-    images: extractImages(media),
+    images: extractWpImages(media),
     likeCount: Number(post.meta?.like_count ?? 0),
     thereCount: Number(post.meta?.there_count ?? 0),
     captureDate: post.meta?.capture_date || null,
     setSlug: night?.slug ?? null,
-  }
-}
-
-function extractImages(media: any) {
-  if (!media) return null
-  const sizes = media.media_details?.sizes ?? {}
-  return {
-    thumbnail: sizes.thumbnail?.source_url ?? null,
-    medium: sizes.medium?.source_url ?? sizes.medium_large?.source_url ?? null,
-    large: sizes.large?.source_url ?? null,
-    full: media.source_url ?? null,
-    width: media.media_details?.width ?? null,
-    height: media.media_details?.height ?? null,
-    alt: media.alt_text || '',
   }
 }

--- a/frontend/server/api/photo/[slug].get.ts
+++ b/frontend/server/api/photo/[slug].get.ts
@@ -33,25 +33,11 @@ export default defineEventHandler(async (event) => {
     camera: post.meta?.camera ?? null,
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
     content: post.content?.rendered ?? '',
-    images: extractImages(media),
+    images: extractWpImages(media),
     series: extractTerms(post, 'series'),
     subjects: extractTerms(post, 'subject'),
   }
 })
-
-function extractImages(media: any) {
-  if (!media) return null
-  const sizes = media.media_details?.sizes ?? {}
-  return {
-    thumbnail: sizes.thumbnail?.source_url ?? null,
-    medium: sizes.medium?.source_url ?? sizes.medium_large?.source_url ?? null,
-    large: sizes.large?.source_url ?? null,
-    full: media.source_url ?? null,
-    width: media.media_details?.width ?? null,
-    height: media.media_details?.height ?? null,
-    alt: media.alt_text || '',
-  }
-}
 
 function extractTerms(post: any, taxonomy: string) {
   const terms = post._embedded?.['wp:term'] ?? []

--- a/frontend/server/api/photo/index.get.ts
+++ b/frontend/server/api/photo/index.get.ts
@@ -65,23 +65,9 @@ function toPhoto(post: any) {
     dateTaken: post.meta?.date_taken ?? null,
     camera: post.meta?.camera ?? null,
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
-    images: extractImages(media),
+    images: extractWpImages(media),
     series: extractTerms(post, 'series'),
     subjects: extractTerms(post, 'subject'),
-  }
-}
-
-function extractImages(media: any) {
-  if (!media) return null
-  const sizes = media.media_details?.sizes ?? {}
-  return {
-    thumbnail: sizes.thumbnail?.source_url ?? null,
-    medium: sizes.medium?.source_url ?? sizes.medium_large?.source_url ?? null,
-    large: sizes.large?.source_url ?? null,
-    full: media.source_url ?? null,
-    width: media.media_details?.width ?? null,
-    height: media.media_details?.height ?? null,
-    alt: media.alt_text || '',
   }
 }
 

--- a/frontend/server/api/wp/categories/[slug].get.ts
+++ b/frontend/server/api/wp/categories/[slug].get.ts
@@ -52,15 +52,7 @@ function toPostSummary(post: any) {
     slug: post.slug ?? '',
     date: post.date ?? '',
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
-    featuredImage: media ? {
-      src: media.source_url
-        ?? media.media_details?.sizes?.large?.source_url
-        ?? media.media_details?.sizes?.medium_large?.source_url
-        ?? null,
-      alt: media.alt_text || '',
-      width: media.media_details?.width ?? null,
-      height: media.media_details?.height ?? null,
-    } : null,
+    featuredImage: extractFeaturedImage(media),
     categories: extractTermGroup(post, 'category'),
     tags: extractTermGroup(post, 'post_tag'),
   }

--- a/frontend/server/api/wp/posts/[slug].get.ts
+++ b/frontend/server/api/wp/posts/[slug].get.ts
@@ -29,12 +29,7 @@ export default defineEventHandler(async (event) => {
     date: post.date ?? '',
     content: await hydrateGalleryImages(post.content?.rendered ?? '', base),
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
-    featuredImage: media ? {
-      src: media.source_url ?? null,
-      alt: media.alt_text || '',
-      width: media.media_details?.width ?? null,
-      height: media.media_details?.height ?? null,
-    } : null,
+    featuredImage: extractFeaturedImage(media),
     categories: extractTermGroup(post, 'category'),
     tags: extractTermGroup(post, 'post_tag'),
   }

--- a/frontend/server/api/wp/projects/[slug].get.ts
+++ b/frontend/server/api/wp/projects/[slug].get.ts
@@ -29,12 +29,7 @@ export default defineEventHandler(async (event) => {
     date: post.date ?? '',
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
     content: post.content?.rendered ?? '',
-    featuredImage: media ? {
-      src: media.source_url ?? null,
-      alt: media.alt_text || '',
-      width: media.media_details?.width ?? null,
-      height: media.media_details?.height ?? null,
-    } : null,
+    featuredImage: extractFeaturedImage(media),
     categories: extractProjectCats(post),
   }
 })

--- a/frontend/server/api/wp/projects/index.get.ts
+++ b/frontend/server/api/wp/projects/index.get.ts
@@ -44,12 +44,7 @@ function toProject(post: any) {
     slug: post.slug ?? '',
     date: post.date ?? '',
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
-    featuredImage: media ? {
-      src: media.source_url ?? null,
-      alt: media.alt_text || '',
-      width: media.media_details?.width ?? null,
-      height: media.media_details?.height ?? null,
-    } : null,
+    featuredImage: extractFeaturedImage(media),
     categories: extractProjectCats(post),
   }
 }

--- a/frontend/server/api/wp/series/[slug].get.ts
+++ b/frontend/server/api/wp/series/[slug].get.ts
@@ -57,13 +57,7 @@ function toPhotoSummary(post: any) {
     title: decodeEntities(post.title?.rendered ?? ''),
     slug: post.slug ?? '',
     archiveNumber: archiveNumber ? String(archiveNumber).padStart(3, '0') : null,
-    images: media ? {
-      thumbnail: media.media_details?.sizes?.thumbnail?.source_url ?? null,
-      medium: media.media_details?.sizes?.medium?.source_url ?? null,
-      large: media.media_details?.sizes?.large?.source_url ?? null,
-      full: media.source_url ?? null,
-      alt: media.alt_text || '',
-    } : null,
+    images: extractWpImages(media),
   }
 }
 
@@ -75,9 +69,6 @@ function toStorySummary(post: any) {
     slug: post.slug ?? '',
     date: post.date ?? '',
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
-    featuredImage: media ? {
-      src: media.source_url ?? null,
-      alt: media.alt_text || '',
-    } : null,
+    featuredImage: extractFeaturedImage(media),
   }
 }

--- a/frontend/server/api/wp/stories.get.ts
+++ b/frontend/server/api/wp/stories.get.ts
@@ -34,6 +34,7 @@ function hasImage(post: any): boolean {
 
 function toStory(post: any) {
   const media = post._embedded?.['wp:featuredmedia']?.[0]
+  const image = extractFeaturedImage(media)
   return {
     id:      post.id,
     title:   decodeEntities(post.title?.rendered ?? ''),
@@ -42,13 +43,9 @@ function toStory(post: any) {
     slug:    post.slug ?? '',
     url:     post.link ?? '',
     image: {
-      src:    media?.source_url
-           ?? media?.media_details?.sizes?.large?.source_url
-           ?? media?.media_details?.sizes?.medium_large?.source_url
-           ?? '',
-      alt:    media?.alt_text || post.title?.rendered || '',
-      width:  media?.media_details?.width  ?? null,
-      height: media?.media_details?.height ?? null,
+      ...image,
+      src: image?.src ?? '',
+      alt: media?.alt_text || post.title?.rendered || '',
     },
   }
 }

--- a/frontend/server/api/wp/stories/[slug].get.ts
+++ b/frontend/server/api/wp/stories/[slug].get.ts
@@ -29,12 +29,7 @@ export default defineEventHandler(async (event) => {
     slug: post.slug ?? '',
     date: post.date ?? '',
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
-    featuredImage: media ? {
-      src: media.source_url ?? null,
-      alt: media.alt_text || '',
-      width: media.media_details?.width ?? null,
-      height: media.media_details?.height ?? null,
-    } : null,
+    featuredImage: extractFeaturedImage(media),
     // Structured block data for the Vue block renderer
     blocks: post.blocks_data ?? [],
     // Resolved photo data keyed by photo ID

--- a/frontend/server/api/wp/stories/index.get.ts
+++ b/frontend/server/api/wp/stories/index.get.ts
@@ -44,12 +44,7 @@ export default defineEventHandler(async (event) => {
       slug: post.slug ?? '',
       date: post.date ?? '',
       excerpt: stripTags(post.excerpt?.rendered ?? ''),
-      featuredImage: media ? {
-        src: media.source_url ?? null,
-        alt: media.alt_text || '',
-        width: media.media_details?.width ?? null,
-        height: media.media_details?.height ?? null,
-      } : null,
+      featuredImage: extractFeaturedImage(media),
       series: extractTerms(post, 'series'),
       subjects: extractTerms(post, 'subject'),
     }

--- a/frontend/server/api/wp/story.get.ts
+++ b/frontend/server/api/wp/story.get.ts
@@ -70,6 +70,9 @@ function hasImage(post: any): boolean {
 
 function toStory(post: any) {
   const media = post._embedded?.['wp:featuredmedia']?.[0]
+  // Proportional WP sizes only (never crops); `variants` reaches the original
+  // so retina screens keep full documentary sharpness.
+  const image = extractFeaturedImage(media)
   return {
     id:      post.id,
     title:   decodeEntities(post.title?.rendered ?? ''),
@@ -78,14 +81,9 @@ function toStory(post: any) {
     slug:    post.slug ?? '',
     url:     post.link ?? '',
     image: {
-      // Full original - documentary photography must not be cropped by WP thumbnails
-      src:    media?.source_url
-           ?? media?.media_details?.sizes?.large?.source_url
-           ?? media?.media_details?.sizes?.medium_large?.source_url
-           ?? '',
-      alt:    media?.alt_text || post.title?.rendered || '',
-      width:  media?.media_details?.width  ?? null,
-      height: media?.media_details?.height ?? null,
+      ...image,
+      src: image?.src ?? '',
+      alt: media?.alt_text || post.title?.rendered || '',
     },
   }
 }

--- a/frontend/server/api/wp/subjects/[slug].get.ts
+++ b/frontend/server/api/wp/subjects/[slug].get.ts
@@ -58,13 +58,7 @@ function toPhotoSummary(post: any) {
     title: decodeEntities(post.title?.rendered ?? ''),
     slug: post.slug ?? '',
     archiveNumber: archiveNumber ? String(archiveNumber).padStart(3, '0') : null,
-    images: media ? {
-      thumbnail: media.media_details?.sizes?.thumbnail?.source_url ?? null,
-      medium: media.media_details?.sizes?.medium?.source_url ?? null,
-      large: media.media_details?.sizes?.large?.source_url ?? null,
-      full: media.source_url ?? null,
-      alt: media.alt_text || '',
-    } : null,
+    images: extractWpImages(media),
   }
 }
 
@@ -76,9 +70,6 @@ function toStorySummary(post: any) {
     slug: post.slug ?? '',
     date: post.date ?? '',
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
-    featuredImage: media ? {
-      src: media.source_url ?? null,
-      alt: media.alt_text || '',
-    } : null,
+    featuredImage: extractFeaturedImage(media),
   }
 }

--- a/frontend/server/api/wp/tags/[slug].get.ts
+++ b/frontend/server/api/wp/tags/[slug].get.ts
@@ -52,15 +52,7 @@ function toPostSummary(post: any) {
     slug: post.slug ?? '',
     date: post.date ?? '',
     excerpt: stripTags(post.excerpt?.rendered ?? ''),
-    featuredImage: media ? {
-      src: media.source_url
-        ?? media.media_details?.sizes?.large?.source_url
-        ?? media.media_details?.sizes?.medium_large?.source_url
-        ?? null,
-      alt: media.alt_text || '',
-      width: media.media_details?.width ?? null,
-      height: media.media_details?.height ?? null,
-    } : null,
+    featuredImage: extractFeaturedImage(media),
     categories: extractTermGroup(post, 'category'),
     tags: extractTermGroup(post, 'post_tag'),
   }

--- a/frontend/server/utils/wp-fetch.ts
+++ b/frontend/server/utils/wp-fetch.ts
@@ -160,27 +160,35 @@ export async function hydrateGalleryImages(html: string, base: string): Promise<
 
   // Batch-resolve the IDs to source URLs in a single REST call.
   const media = await wpFetch<any[]>(
-    `${base}/wp-json/wp/v2/media?include=${[...ids].join(',')}&per_page=100&_fields=id,source_url,alt_text`
+    `${base}/wp-json/wp/v2/media?include=${[...ids].join(',')}&per_page=100&_fields=id,source_url,alt_text,media_details`
   )
   if (!media?.length) return html
 
-  const byId = new Map<number, { src: string; alt: string }>()
+  const byId = new Map<number, { src: string; srcset: string; alt: string }>()
   for (const m of media) {
     if (m?.id && m?.source_url) {
-      byId.set(Number(m.id), { src: m.source_url, alt: m.alt_text || '' })
+      // These galleries render inside the 42rem article column, so 1024px
+      // candidates suffice; the original only serves DPR>1.5 fallback cases.
+      const variants = extractVariants(m).filter((v) => v.width <= 1024)
+      const src = variants.length ? variants[variants.length - 1].url : m.source_url
+      const srcset = variants.length > 1 ? variants.map((v) => `${v.url} ${v.width}w`).join(', ') : ''
+      byId.set(Number(m.id), { src, srcset, alt: m.alt_text || '' })
     }
   }
   if (byId.size === 0) return html
 
-  // Inject src (+ alt + lazy loading) into each matching img tag.
+  // Inject src (+ srcset + alt + lazy loading) into each matching img tag.
   return html.replace(imgRe, (tag) => {
     if (/\bsrc\s*=/i.test(tag)) return tag
     const m = tag.match(/\bdata-id\s*=\s*["']?(\d+)/i)
     const info = m && byId.get(Number(m[1]))
     if (!info) return tag
+    const srcsetAttr = info.srcset
+      ? ` srcset="${escapeAttr(info.srcset)}" sizes="(max-width: 719px) 100vw, 672px"`
+      : ''
     const altAttr = /\balt\s*=/i.test(tag) ? '' : ` alt="${escapeAttr(info.alt)}"`
     const loadingAttr = /\bloading\s*=/i.test(tag) ? '' : ' loading="lazy"'
-    return tag.replace(/^<img\b/i, `<img src="${escapeAttr(info.src)}"${altAttr}${loadingAttr}`)
+    return tag.replace(/^<img\b/i, `<img src="${escapeAttr(info.src)}"${srcsetAttr}${altAttr}${loadingAttr} decoding="async"`)
   })
 }
 

--- a/frontend/server/utils/wp-image.ts
+++ b/frontend/server/utils/wp-image.ts
@@ -1,0 +1,63 @@
+import type { PhotoImages, FeaturedImage, WpImageVariant } from '~/types/photo'
+
+/**
+ * Proportional (uncropped) WP sizes, ascending. `thumbnail` (150x150 crop) and
+ * the custom mauer_stills_thumb_* sizes are crops — never valid srcset
+ * candidates for the original aspect ratio.
+ */
+const SRCSET_SIZES = ['medium', 'medium_large', 'large', '1536x1536', '2048x2048']
+
+/**
+ * Build the list of renderable variants from whatever sizes actually exist on
+ * this media item (2018-era uploads lack 1536/2048), ending with the original.
+ */
+export function extractVariants(media: any): WpImageVariant[] {
+  const details = media?.media_details ?? {}
+  const sizes = details.sizes ?? {}
+  const out: WpImageVariant[] = []
+  for (const name of SRCSET_SIZES) {
+    const s = sizes[name]
+    if (s?.source_url && Number(s.width) > 0) {
+      out.push({ url: s.source_url, width: Number(s.width), height: Number(s.height) || 0 })
+    }
+  }
+  if (media?.source_url && Number(details.width) > 0) {
+    out.push({ url: media.source_url, width: Number(details.width), height: Number(details.height) || 0 })
+  }
+  out.sort((a, b) => a.width - b.width)
+  // The original can share a width with the largest named size on small uploads.
+  return out.filter((v, i) => i === 0 || v.width !== out[i - 1].width)
+}
+
+/** Canonical `images` object for photo/event endpoints. */
+export function extractWpImages(media: any): PhotoImages | null {
+  if (!media) return null
+  const sizes = media.media_details?.sizes ?? {}
+  return {
+    thumbnail: sizes.thumbnail?.source_url ?? null,
+    medium: sizes.medium?.source_url ?? sizes.medium_large?.source_url ?? null,
+    large: sizes.large?.source_url ?? null,
+    full: media.source_url ?? null,
+    width: media.media_details?.width ?? null,
+    height: media.media_details?.height ?? null,
+    alt: media.alt_text || '',
+    variants: extractVariants(media),
+  }
+}
+
+/**
+ * Canonical `featuredImage` object for post/story/project endpoints. `src` is a
+ * display default (large-first), not the multi-megabyte original; retina reach
+ * comes from `variants`.
+ */
+export function extractFeaturedImage(media: any): FeaturedImage | null {
+  if (!media) return null
+  const sizes = media.media_details?.sizes ?? {}
+  return {
+    src: sizes.large?.source_url ?? sizes.medium_large?.source_url ?? media.source_url ?? null,
+    alt: media.alt_text || '',
+    width: media.media_details?.width ?? null,
+    height: media.media_details?.height ?? null,
+    variants: extractVariants(media),
+  }
+}

--- a/frontend/types/photo.ts
+++ b/frontend/types/photo.ts
@@ -1,3 +1,10 @@
+/** One renderable size of a WP image (uncropped, proportional). */
+export interface WpImageVariant {
+  url: string
+  width: number
+  height: number
+}
+
 /** Image data from WP featured media. */
 export interface PhotoImages {
   thumbnail: string | null
@@ -7,6 +14,21 @@ export interface PhotoImages {
   width: number | null
   height: number | null
   alt: string
+  /**
+   * Proportional size variants ascending by width, ending with the original.
+   * Absent in SWR-cached responses that predate this field — consumers must
+   * degrade to the flat fields above.
+   */
+  variants?: WpImageVariant[]
+}
+
+/** Shared featured-image shape for posts/stories/projects. */
+export interface FeaturedImage {
+  src: string | null
+  alt: string
+  width?: number | null
+  height?: number | null
+  variants?: WpImageVariant[]
 }
 
 /** A taxonomy term (series or subject). */
@@ -81,7 +103,7 @@ export interface Story {
   slug: string
   date: string
   excerpt: string
-  featuredImage: { src: string | null; alt: string; width?: number | null; height?: number | null } | null
+  featuredImage: FeaturedImage | null
   blocks: StoryBlock[]
   resolvedPhotos: Record<number, ResolvedPhoto>
   contentRendered: string
@@ -96,7 +118,7 @@ export interface StorySummary {
   slug: string
   date: string
   excerpt: string
-  featuredImage: { src: string | null; alt: string; width?: number | null; height?: number | null } | null
+  featuredImage: FeaturedImage | null
   series: TaxonomyTerm[]
   subjects: TaxonomyTerm[]
 }
@@ -118,7 +140,7 @@ export interface TaxonomyPageResponse {
     title: string
     slug: string
     archiveNumber: string | null
-    images: Omit<PhotoImages, 'width' | 'height'> | null
+    images: PhotoImages | null
   }>
   photosTotal: number
   photosTotalPages: number

--- a/frontend/utils/wp-srcset.ts
+++ b/frontend/utils/wp-srcset.ts
@@ -1,0 +1,61 @@
+import type { PhotoImages, FeaturedImage, WpImageVariant } from '~/types/photo'
+
+export interface SrcsetAttrs {
+  src: string
+  srcset?: string
+  width?: number
+  height?: number
+}
+
+/**
+ * Build img attributes from WP size variants, optionally capped at maxWidth
+ * (grids don't need the original). Always keeps at least the smallest
+ * candidate; `src` is the largest allowed one as the no-srcset fallback.
+ */
+export function buildSrcset(
+  variants: WpImageVariant[] | undefined,
+  maxWidth?: number,
+): SrcsetAttrs | null {
+  if (!variants?.length) return null
+  let list = maxWidth ? variants.filter((v) => v.width <= maxWidth) : variants
+  if (!list.length) list = [variants[0]]
+  const largest = list[list.length - 1]
+  return {
+    src: largest.url,
+    srcset: list.length > 1 ? list.map((v) => `${v.url} ${v.width}w`).join(', ') : undefined,
+    width: largest.width,
+    height: largest.height || undefined,
+  }
+}
+
+/**
+ * Adapter for ResolvedPhoto.images (a Record of WP size name -> file), as
+ * produced WP-side by _resolve_photos. Drops cropped sizes (thumbnail,
+ * mauer_stills_thumb_*) which would lie about the aspect ratio.
+ */
+export function variantsFromResolved(
+  images: Record<string, { url: string; width: number; height: number }> | undefined,
+): WpImageVariant[] {
+  if (!images) return []
+  return Object.entries(images)
+    .filter(([name]) => name !== 'thumbnail' && !name.startsWith('mauer_'))
+    .map(([, v]) => v)
+    .filter((v) => !!v?.url && v.width > 0)
+    .sort((a, b) => a.width - b.width)
+    .filter((v, i, arr) => i === 0 || v.width !== arr[i - 1].width)
+}
+
+/**
+ * Degrade path for API payloads cached before `variants` existed: pick a
+ * single flat-field URL. No widths known, so no srcset.
+ */
+export function fallbackSrc(
+  img: PhotoImages | FeaturedImage | null | undefined,
+  prefer: 'small' | 'large' = 'small',
+): string {
+  if (!img) return ''
+  const p = img as any
+  return prefer === 'small'
+    ? (p.medium ?? p.large ?? p.src ?? p.full ?? '')
+    : (p.large ?? p.full ?? p.src ?? p.medium ?? '')
+}


### PR DESCRIPTION
## Problem

Photographs loaded slowly because nearly every page served the untouched full-resolution WordPress original (`media.source_url`) — with `big_image_size_threshold` disabled on the photo WP, that's native camera resolution. Measured: **/archive loaded 15.5 MB of images** (12 originals averaging 1.3 MB) as grid thumbnails; post heroes shipped 1–1.4 MB JPEGs. No `srcset` anywhere except one buggy spot in WallSection.

## Approach

Use the size variants WP already generates (300/768/1024/1536/2048), with hand-built `srcset`/`sizes` — no @nuxt/image/IPX, no new infrastructure.

- **`server/utils/wp-image.ts`** — shared extractor producing a per-image `variants` array from whatever sizes actually exist (2018-era uploads lacking 1536/2048 degrade gracefully; cropped sizes excluded). All 15 BFF endpoints now use it; existing flat fields kept so SWR-cached payloads from before the deploy still render.
- **`utils/wp-srcset.ts` + `components/WpImage.vue` + `composables/useHeroPreload.ts`** — one rendering path: `srcset`/`sizes`/`width`/`height`, lazy + `decoding=async` by default, `eager` + `fetchpriority=high` + `<link rel=preload>` for LCP heroes.
- **Quality preserved:** grids cap candidates at 1024px, but hero/lightbox srcsets span up to the full original — large retina screens still fetch maximum sharpness.
- **Bug fixes:** WallSection srcset lied about widths (768px files labelled `300w`); EventHero eager-loaded all 20 marquee images (now first 5); project gallery tiles used the full-size lightbox `<a href>` as tile src (now the sized img + WP's own srcset); legacy gallery hydration now injects srcset.

## Result

**/archive: 15.5 MB → 1.73 MB** at DPR 1 (measured against the built server). Post hero LCP request drops from ~1.4 MB to a ~200–400 KB candidate.

## Verification

- `npm run build` clean.
- Rendered HTML verified: grid tiles carry srcset with 300/768/1024 candidates; hero pages emit `<link rel=preload imagesrcset>`.
- Playwright: all image-related specs green (lightbox-close, cold-turkey-*, homepage, navigation). The terminal/status-block/blog-images failures are pre-existing and environmental (verified identical against prod; terminal never boots without scrolling, and `/sites/...` images only resolve behind prod Traefik).

Companion PR on photo.madsnorgaard.net adds year-long immutable Cache-Control for uploads via Traefik labels.